### PR TITLE
fix to rm items outside viewport

### DIFF
--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -190,6 +190,7 @@ const useStore = create<State>()(
 						// Set isShown to false for tiles outside the viewport
 						newGrid.set(key, {
 							...value,
+							entity_type: { val: "None" },
 							isShown: false,
 						});
 					}


### PR DESCRIPTION
- fixes the issue where items previously shown on the grid remain on screen even though they are fogged out