### PR TITLE
Add terrain to the tile map

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Run `bun dev` in `packages/client`
 
 Add IS_MOCK=true to .env in `packages/client`
 Rerun `sh start.sh` in  `packages/server`
+
+## Running with Dev features:
+Add IS_MOCK=true to .env in `packages/client`, this enables certain dev features like bypassing the login and the TileMapEditor
+

--- a/packages/client/.env
+++ b/packages/client/.env
@@ -1,2 +1,0 @@
-VITE_SERVER_URL=http://localhost:8001
-VITE_LOGIN_SERVER_URL=https://frog-zone-login.vercel.app

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,3 +1,6 @@
 VITE_SERVER_URL=http://localhost:8001
 VITE_LOGIN_SERVER_URL=https://frog-zone-login.vercel.app
+# if true uses the Mock backend (plaintext)
 VITE_IS_MOCK=true
+# if true allows dev and debug features such as bypassing login
+VITE_DEV_MODE=true

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { GameFinishedOverlay } from "./game/components/GameFinishedOverlay";
 import { Login } from "./game/components/Login";
+import { TileMapEditor } from "./components/TileMapEditor/TileMapEditor";
 import { MoveCountdownTimer } from "./game/components/MoveCountdown";
 import { PlayerInfo } from "./game/components/PlayerInfo";
 import { WaitingForPlayersOverlay } from "./game/components/WaitingForPlayersOverlay";
@@ -43,7 +44,6 @@ function App() {
 							<AreYouThere />
 						</>
 					)}
-					{/* <button onClick={() => confettiReward()}>Confetti</button> */}
 
 					{gameId &&
 						gameStatus === "waiting_for_players" &&
@@ -68,6 +68,7 @@ function App() {
 						)}
 				</>
 			)}
+			{import.meta.env.VITE_DEV_MODE && <TileMapEditor />}
 		</div>
 	);
 }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -11,6 +11,7 @@ import { getPlayerId } from "./utils/getPlayerId";
 import { AreYouThere } from "./game/components/AreYouThere";
 import { EnterGameAnimation } from "./game/components/EnterGameAnimation";
 import { QuitGameModal } from "./game/components/QuitGameModal";
+import { DEV_MODE } from "./const/env.const";
 
 const MIN_PLAYERS = 4;
 const MIN_PLAYERS_TO_FORCE_START = 1;
@@ -22,7 +23,7 @@ function App() {
 	const isLoggedIn = useStore((state) => state.isLoggedIn);
 	return (
 		<div>
-			<Login />
+			{!DEV_MODE && <Login />}
 			{isLoggedIn && (
 				<>
 					<PlayerInfo playerId={Number(playerId)} />
@@ -68,7 +69,7 @@ function App() {
 						)}
 				</>
 			)}
-			{import.meta.env.VITE_DEV_MODE && <TileMapEditor />}
+			{DEV_MODE && <TileMapEditor />}
 		</div>
 	);
 }

--- a/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
+++ b/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import tileMapConfig from "../../const/tile.config.json";
 import { Button } from "../Button";
 import { TerrainType } from "../../game/store";
+import {
+	findBorderingWaterCoordinates,
+	Grid,
+} from "../../utils/findBorderingWaterCoordinates";
 
 /* TileMapEditor allows us to easily visualize and edit the game map. 
 Clicking on the tiles toggles them between LAND and WATER.
@@ -11,42 +15,12 @@ Exporting the JSON exports a the json to paste into the tile.config.json */
 const ITEM_COORDS = ["1,8", "2,9", "3,3", "1,1"];
 const PLAYER_COORDS = ["1,2", "1,3", "4,5", "5,6"];
 
-interface Grid {
-	[key: string]: {
-		terrainType: TerrainType;
-	};
-}
-
-const findBorderingWaterCoordinates = (grid: Grid): string[] => {
-	const result: string[] = [];
-	const getNeighbors = (x: number, y: number): string[] => [
-		`${x - 1},${y}`, // Up
-		`${x + 1},${y}`, // Down
-		`${x},${y - 1}`, // Left
-		`${x},${y + 1}`, // Right
-	];
-
-	for (const key in grid) {
-		if (grid[key as keyof Grid].terrainType === "WATER") {
-			const [x, y] = key.split(",").map(Number);
-
-			const hasLandNeighbor = getNeighbors(x, y).some(
-				(neighbor) => grid[neighbor]?.terrainType === "LAND",
-			);
-			if (hasLandNeighbor) {
-				result.push(key);
-			}
-		}
-	}
-
-	return result;
-};
-
 export const TileMapEditor = () => {
 	const [gridData, setGridData] = useState(tileMapConfig);
 	const [isVisible, setIsVisible] = useState(false);
-	const waterCoordinatesBorderingLand =
-		findBorderingWaterCoordinates(gridData);
+	const waterCoordinatesBorderingLand = findBorderingWaterCoordinates(
+		gridData as Grid,
+	);
 
 	const toggleTerrain = (x: number, y: number) => {
 		const key = `${x},${y}`;

--- a/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
+++ b/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
@@ -27,8 +27,11 @@ export const TileMapEditor = () => {
 		setGridData((prevData) => ({
 			...prevData,
 			[key]: {
-				terrainType: prevData[key as keyof typeof prevData]
-					.terrainType as TerrainType,
+				terrainType:
+					prevData[key as keyof typeof prevData].terrainType ===
+					TerrainType.LAND
+						? TerrainType.WATER
+						: TerrainType.LAND,
 			},
 		}));
 	};

--- a/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
+++ b/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
@@ -11,9 +11,42 @@ Exporting the JSON exports a the json to paste into the tile.config.json */
 const ITEM_COORDS = ["1,8", "2,9", "3,3", "1,1"];
 const PLAYER_COORDS = ["1,2", "1,3", "4,5", "5,6"];
 
+interface Grid {
+	[key: string]: {
+		terrainType: TerrainType;
+	};
+}
+
+const findBorderingWaterCoordinates = (grid: Grid): string[] => {
+	const result: string[] = [];
+	const getNeighbors = (x: number, y: number): string[] => [
+		`${x - 1},${y}`, // Up
+		`${x + 1},${y}`, // Down
+		`${x},${y - 1}`, // Left
+		`${x},${y + 1}`, // Right
+	];
+
+	for (const key in grid) {
+		if (grid[key as keyof Grid].terrainType === "WATER") {
+			const [x, y] = key.split(",").map(Number);
+
+			const hasLandNeighbor = getNeighbors(x, y).some(
+				(neighbor) => grid[neighbor]?.terrainType === "LAND",
+			);
+			if (hasLandNeighbor) {
+				result.push(key);
+			}
+		}
+	}
+
+	return result;
+};
+
 export const TileMapEditor = () => {
 	const [gridData, setGridData] = useState(tileMapConfig);
 	const [isVisible, setIsVisible] = useState(false);
+	const waterCoordinatesBorderingLand =
+		findBorderingWaterCoordinates(gridData);
 
 	const toggleTerrain = (x: number, y: number) => {
 		const key = `${x},${y}`;
@@ -99,6 +132,10 @@ export const TileMapEditor = () => {
 										backgroundColor:
 											terrainType === "LAND"
 												? "green"
+												: waterCoordinatesBorderingLand.includes(
+														key,
+												  )
+												? "#03a9f4"
 												: "blue",
 										display: "flex",
 										alignItems: "center",

--- a/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
+++ b/packages/client/src/components/TileMapEditor/TileMapEditor.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import tileMapConfig from "../../const/tile.config.json";
+import { Button } from "../Button";
+import { TerrainType } from "../../game/store";
+
+/* TileMapEditor allows us to easily visualize and edit the game map. 
+Clicking on the tiles toggles them between LAND and WATER.
+Exporting the JSON exports a the json to paste into the tile.config.json */
+
+// Edit these to visualize player or item locations on the game map
+const ITEM_COORDS = ["1,8", "2,9", "3,3", "1,1"];
+const PLAYER_COORDS = ["1,2", "1,3", "4,5", "5,6"];
+
+export const TileMapEditor = () => {
+	const [gridData, setGridData] = useState(tileMapConfig);
+	const [isVisible, setIsVisible] = useState(false);
+
+	const toggleTerrain = (x: number, y: number) => {
+		const key = `${x},${y}`;
+		setGridData((prevData) => ({
+			...prevData,
+			[key]: {
+				terrainType: prevData[key as keyof typeof prevData]
+					.terrainType as TerrainType,
+			},
+		}));
+	};
+
+	const exportJson = () => {
+		const jsonString = JSON.stringify(gridData, null, 2);
+		const blob = new Blob([jsonString], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
+
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = "terrain-grid.json";
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	};
+
+	const handleKeyDown = (event: KeyboardEvent) => {
+		if (event.ctrlKey && event.key === "e") {
+			event.preventDefault();
+			setIsVisible((prev) => !prev);
+		}
+	};
+
+	useEffect(() => {
+		window.addEventListener("keydown", handleKeyDown);
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+		};
+	}, []);
+
+	return (
+		<>
+			{isVisible && (
+				<div
+					style={{
+						position: "absolute" as "absolute",
+						top: 0,
+						left: 0,
+						minWidth: "100vw",
+						minHeight: "100vh",
+						backgroundColor: "rgba(0, 0, 0, 1)",
+						alignItems: "center",
+						textAlign: "center" as "center",
+						zIndex: 1000,
+					}}
+				>
+					<Button
+						onClick={exportJson}
+						style={{ marginTop: "20px", marginBottom: "20px" }}
+					>
+						Export JSON
+					</Button>
+					<div
+						className="grid"
+						style={{
+							display: "grid",
+							gridTemplateColumns: "repeat(64, 1.5vw)",
+							gridGap: "2px",
+						}}
+					>
+						{Object.keys(gridData).map((key) => {
+							const [x, y] = key.split(",").map(Number);
+							const terrainType =
+								gridData[key as keyof typeof gridData]
+									.terrainType;
+							return (
+								<div
+									key={key}
+									onClick={() => toggleTerrain(x, y)}
+									style={{
+										width: "1.5vw",
+										height: "1.5vw",
+										backgroundColor:
+											terrainType === "LAND"
+												? "green"
+												: "blue",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										color: "white",
+										cursor: "pointer",
+									}}
+								>
+									{PLAYER_COORDS.includes(key)
+										? "P"
+										: ITEM_COORDS.includes(key)
+										? "I"
+										: ""}
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</>
+	);
+};

--- a/packages/client/src/const/env.const.ts
+++ b/packages/client/src/const/env.const.ts
@@ -1,3 +1,4 @@
 export const SERVER_URL = import.meta.env.VITE_SERVER_URL;
 export const LOGIN_SERVER_URL = import.meta.env.VITE_LOGIN_SERVER_URL;
 export const IS_MOCK = import.meta.env.VITE_IS_MOCK;
+export const DEV_MODE = import.meta.env.VITE_DEV_MODE;

--- a/packages/client/src/const/tile.config.json
+++ b/packages/client/src/const/tile.config.json
@@ -66,10 +66,10 @@
 		"terrainType": "LAND"
 	},
 	"0,22": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,23": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,24": {
 		"terrainType": "LAND"
@@ -135,16 +135,16 @@
 		"terrainType": "LAND"
 	},
 	"0,45": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,46": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"0,49": {
 		"terrainType": "LAND"
@@ -543,13 +543,13 @@
 		"terrainType": "LAND"
 	},
 	"2,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"2,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"2,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"2,56": {
 		"terrainType": "LAND"
@@ -615,13 +615,13 @@
 		"terrainType": "LAND"
 	},
 	"3,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,16": {
 		"terrainType": "LAND"
@@ -672,19 +672,19 @@
 		"terrainType": "LAND"
 	},
 	"3,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,37": {
 		"terrainType": "LAND"
@@ -732,22 +732,22 @@
 		"terrainType": "LAND"
 	},
 	"3,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"3,58": {
 		"terrainType": "LAND"
@@ -807,13 +807,13 @@
 		"terrainType": "LAND"
 	},
 	"4,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,16": {
 		"terrainType": "LAND"
@@ -861,25 +861,25 @@
 		"terrainType": "LAND"
 	},
 	"4,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,38": {
 		"terrainType": "LAND"
@@ -927,19 +927,19 @@
 		"terrainType": "LAND"
 	},
 	"4,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"4,58": {
 		"terrainType": "LAND"
@@ -966,10 +966,10 @@
 		"terrainType": "LAND"
 	},
 	"5,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,4": {
 		"terrainType": "LAND"
@@ -999,13 +999,13 @@
 		"terrainType": "LAND"
 	},
 	"5,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,16": {
 		"terrainType": "LAND"
@@ -1050,31 +1050,31 @@
 		"terrainType": "LAND"
 	},
 	"5,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,39": {
 		"terrainType": "LAND"
@@ -1119,13 +1119,13 @@
 		"terrainType": "LAND"
 	},
 	"5,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"5,56": {
 		"terrainType": "LAND"
@@ -1215,7 +1215,7 @@
 		"terrainType": "LAND"
 	},
 	"6,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,22": {
 		"terrainType": "LAND"
@@ -1242,31 +1242,31 @@
 		"terrainType": "LAND"
 	},
 	"6,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"6,39": {
 		"terrainType": "LAND"
@@ -1404,10 +1404,10 @@
 		"terrainType": "LAND"
 	},
 	"7,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,22": {
 		"terrainType": "LAND"
@@ -1440,19 +1440,19 @@
 		"terrainType": "LAND"
 	},
 	"7,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"7,37": {
 		"terrainType": "LAND"
@@ -1596,13 +1596,13 @@
 		"terrainType": "LAND"
 	},
 	"8,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,22": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,23": {
 		"terrainType": "LAND"
@@ -1632,16 +1632,16 @@
 		"terrainType": "LAND"
 	},
 	"8,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"8,36": {
 		"terrainType": "LAND"
@@ -1827,13 +1827,13 @@
 		"terrainType": "LAND"
 	},
 	"9,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"9,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"9,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"9,36": {
 		"terrainType": "LAND"
@@ -1950,7 +1950,7 @@
 		"terrainType": "LAND"
 	},
 	"10,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"10,11": {
 		"terrainType": "LAND"
@@ -2103,13 +2103,13 @@
 		"terrainType": "LAND"
 	},
 	"10,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"10,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"10,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,0": {
 		"terrainType": "LAND"
@@ -2139,16 +2139,16 @@
 		"terrainType": "LAND"
 	},
 	"11,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,13": {
 		"terrainType": "LAND"
@@ -2286,22 +2286,22 @@
 		"terrainType": "LAND"
 	},
 	"11,58": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,59": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,60": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"11,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,0": {
 		"terrainType": "LAND"
@@ -2325,22 +2325,22 @@
 		"terrainType": "LAND"
 	},
 	"12,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,13": {
 		"terrainType": "LAND"
@@ -2478,22 +2478,22 @@
 		"terrainType": "LAND"
 	},
 	"12,58": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,59": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,60": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"12,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,0": {
 		"terrainType": "LAND"
@@ -2514,25 +2514,25 @@
 		"terrainType": "LAND"
 	},
 	"13,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,13": {
 		"terrainType": "LAND"
@@ -2676,52 +2676,52 @@
 		"terrainType": "LAND"
 	},
 	"13,60": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"13,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,12": {
 		"terrainType": "LAND"
@@ -2871,43 +2871,43 @@
 		"terrainType": "LAND"
 	},
 	"14,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"14,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"15,10": {
 		"terrainType": "LAND"
@@ -3072,31 +3072,31 @@
 		"terrainType": "LAND"
 	},
 	"16,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,9": {
 		"terrainType": "LAND"
@@ -3129,13 +3129,13 @@
 		"terrainType": "LAND"
 	},
 	"16,19": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,22": {
 		"terrainType": "LAND"
@@ -3174,13 +3174,13 @@
 		"terrainType": "LAND"
 	},
 	"16,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"16,37": {
 		"terrainType": "LAND"
@@ -3264,16 +3264,16 @@
 		"terrainType": "LAND"
 	},
 	"17,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,4": {
 		"terrainType": "LAND"
@@ -3366,13 +3366,13 @@
 		"terrainType": "LAND"
 	},
 	"17,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,37": {
 		"terrainType": "LAND"
@@ -3414,7 +3414,7 @@
 		"terrainType": "LAND"
 	},
 	"17,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,51": {
 		"terrainType": "LAND"
@@ -3423,10 +3423,10 @@
 		"terrainType": "LAND"
 	},
 	"17,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"17,55": {
 		"terrainType": "LAND"
@@ -3456,16 +3456,16 @@
 		"terrainType": "LAND"
 	},
 	"18,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,4": {
 		"terrainType": "LAND"
@@ -3558,13 +3558,13 @@
 		"terrainType": "LAND"
 	},
 	"18,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,37": {
 		"terrainType": "LAND"
@@ -3606,7 +3606,7 @@
 		"terrainType": "LAND"
 	},
 	"18,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,51": {
 		"terrainType": "LAND"
@@ -3615,10 +3615,10 @@
 		"terrainType": "LAND"
 	},
 	"18,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"18,55": {
 		"terrainType": "LAND"
@@ -3648,16 +3648,16 @@
 		"terrainType": "LAND"
 	},
 	"19,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"19,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"19,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"19,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"19,4": {
 		"terrainType": "LAND"
@@ -3840,19 +3840,19 @@
 		"terrainType": "LAND"
 	},
 	"20,0": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"20,1": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"20,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"20,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"20,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"20,5": {
 		"terrainType": "LAND"
@@ -4038,16 +4038,16 @@
 		"terrainType": "LAND"
 	},
 	"21,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"21,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"21,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"21,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"21,6": {
 		"terrainType": "LAND"
@@ -4182,7 +4182,7 @@
 		"terrainType": "LAND"
 	},
 	"21,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"21,51": {
 		"terrainType": "LAND"
@@ -4230,19 +4230,19 @@
 		"terrainType": "LAND"
 	},
 	"22,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,7": {
 		"terrainType": "LAND"
@@ -4374,7 +4374,7 @@
 		"terrainType": "LAND"
 	},
 	"22,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,51": {
 		"terrainType": "LAND"
@@ -4410,10 +4410,10 @@
 		"terrainType": "LAND"
 	},
 	"22,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"22,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,0": {
 		"terrainType": "LAND"
@@ -4425,31 +4425,31 @@
 		"terrainType": "LAND"
 	},
 	"23,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,12": {
 		"terrainType": "LAND"
@@ -4506,10 +4506,10 @@
 		"terrainType": "LAND"
 	},
 	"23,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,32": {
 		"terrainType": "LAND"
@@ -4563,13 +4563,13 @@
 		"terrainType": "LAND"
 	},
 	"23,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,52": {
 		"terrainType": "LAND"
@@ -4602,10 +4602,10 @@
 		"terrainType": "LAND"
 	},
 	"23,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"23,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,0": {
 		"terrainType": "LAND"
@@ -4623,28 +4623,28 @@
 		"terrainType": "LAND"
 	},
 	"24,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,13": {
 		"terrainType": "LAND"
@@ -4680,40 +4680,40 @@
 		"terrainType": "LAND"
 	},
 	"24,24": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,25": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,36": {
 		"terrainType": "LAND"
@@ -4749,25 +4749,25 @@
 		"terrainType": "LAND"
 	},
 	"24,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"24,54": {
 		"terrainType": "LAND"
@@ -4818,25 +4818,25 @@
 		"terrainType": "LAND"
 	},
 	"25,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,13": {
 		"terrainType": "LAND"
@@ -4872,40 +4872,40 @@
 		"terrainType": "LAND"
 	},
 	"25,24": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,25": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,36": {
 		"terrainType": "LAND"
@@ -4944,22 +4944,22 @@
 		"terrainType": "LAND"
 	},
 	"25,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"25,54": {
 		"terrainType": "LAND"
@@ -5016,19 +5016,19 @@
 		"terrainType": "LAND"
 	},
 	"26,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,13": {
 		"terrainType": "LAND"
@@ -5076,19 +5076,19 @@
 		"terrainType": "LAND"
 	},
 	"26,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,33": {
 		"terrainType": "LAND"
@@ -5136,22 +5136,22 @@
 		"terrainType": "LAND"
 	},
 	"26,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"26,54": {
 		"terrainType": "LAND"
@@ -5211,22 +5211,22 @@
 		"terrainType": "LAND"
 	},
 	"27,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,15": {
 		"terrainType": "LAND"
@@ -5235,7 +5235,7 @@
 		"terrainType": "LAND"
 	},
 	"27,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,18": {
 		"terrainType": "LAND"
@@ -5271,10 +5271,10 @@
 		"terrainType": "LAND"
 	},
 	"27,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,31": {
 		"terrainType": "LAND"
@@ -5331,13 +5331,13 @@
 		"terrainType": "LAND"
 	},
 	"27,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"27,52": {
 		"terrainType": "LAND"
@@ -5403,34 +5403,34 @@
 		"terrainType": "LAND"
 	},
 	"28,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,16": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,18": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"28,19": {
 		"terrainType": "LAND"
@@ -5601,28 +5601,28 @@
 		"terrainType": "LAND"
 	},
 	"29,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,16": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,18": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"29,19": {
 		"terrainType": "LAND"
@@ -5805,13 +5805,13 @@
 		"terrainType": "LAND"
 	},
 	"30,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"30,16": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"30,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"30,18": {
 		"terrainType": "LAND"
@@ -6069,13 +6069,13 @@
 		"terrainType": "LAND"
 	},
 	"31,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"31,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"31,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"31,42": {
 		"terrainType": "LAND"
@@ -6135,13 +6135,13 @@
 		"terrainType": "LAND"
 	},
 	"31,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"31,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"31,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,0": {
 		"terrainType": "LAND"
@@ -6261,16 +6261,16 @@
 		"terrainType": "LAND"
 	},
 	"32,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,43": {
 		"terrainType": "LAND"
@@ -6324,16 +6324,16 @@
 		"terrainType": "LAND"
 	},
 	"32,60": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"32,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,0": {
 		"terrainType": "LAND"
@@ -6453,19 +6453,19 @@
 		"terrainType": "LAND"
 	},
 	"33,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,44": {
 		"terrainType": "LAND"
@@ -6510,22 +6510,22 @@
 		"terrainType": "LAND"
 	},
 	"33,58": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,59": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,60": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"33,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,0": {
 		"terrainType": "LAND"
@@ -6534,34 +6534,34 @@
 		"terrainType": "LAND"
 	},
 	"34,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,12": {
 		"terrainType": "LAND"
@@ -6645,19 +6645,19 @@
 		"terrainType": "LAND"
 	},
 	"34,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,44": {
 		"terrainType": "LAND"
@@ -6711,10 +6711,10 @@
 		"terrainType": "LAND"
 	},
 	"34,61": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"34,63": {
 		"terrainType": "LAND"
@@ -6726,37 +6726,37 @@
 		"terrainType": "LAND"
 	},
 	"35,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"35,13": {
 		"terrainType": "LAND"
@@ -6918,34 +6918,34 @@
 		"terrainType": "LAND"
 	},
 	"36,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"36,12": {
 		"terrainType": "LAND"
@@ -7569,16 +7569,16 @@
 		"terrainType": "LAND"
 	},
 	"39,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"39,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"39,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"39,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"39,31": {
 		"terrainType": "LAND"
@@ -7731,7 +7731,7 @@
 		"terrainType": "LAND"
 	},
 	"40,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"40,18": {
 		"terrainType": "LAND"
@@ -7761,16 +7761,16 @@
 		"terrainType": "LAND"
 	},
 	"40,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"40,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"40,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"40,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"40,31": {
 		"terrainType": "LAND"
@@ -7914,16 +7914,16 @@
 		"terrainType": "LAND"
 	},
 	"41,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,16": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,18": {
 		"terrainType": "LAND"
@@ -7953,16 +7953,16 @@
 		"terrainType": "LAND"
 	},
 	"41,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"41,31": {
 		"terrainType": "LAND"
@@ -8106,16 +8106,16 @@
 		"terrainType": "LAND"
 	},
 	"42,14": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,15": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,16": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,17": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,18": {
 		"terrainType": "LAND"
@@ -8232,10 +8232,10 @@
 		"terrainType": "LAND"
 	},
 	"42,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,58": {
 		"terrainType": "LAND"
@@ -8250,10 +8250,10 @@
 		"terrainType": "LAND"
 	},
 	"42,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"42,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,0": {
 		"terrainType": "LAND"
@@ -8280,13 +8280,13 @@
 		"terrainType": "LAND"
 	},
 	"43,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,11": {
 		"terrainType": "LAND"
@@ -8400,13 +8400,13 @@
 		"terrainType": "LAND"
 	},
 	"43,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,51": {
 		"terrainType": "LAND"
@@ -8424,10 +8424,10 @@
 		"terrainType": "LAND"
 	},
 	"43,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,58": {
 		"terrainType": "LAND"
@@ -8442,10 +8442,10 @@
 		"terrainType": "LAND"
 	},
 	"43,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"43,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,0": {
 		"terrainType": "LAND"
@@ -8469,16 +8469,16 @@
 		"terrainType": "LAND"
 	},
 	"44,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,9": {
 		"terrainType": "LAND"
 	},
 	"44,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,11": {
 		"terrainType": "LAND"
@@ -8589,37 +8589,37 @@
 		"terrainType": "LAND"
 	},
 	"44,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,58": {
 		"terrainType": "LAND"
@@ -8634,10 +8634,10 @@
 		"terrainType": "LAND"
 	},
 	"44,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"44,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,0": {
 		"terrainType": "LAND"
@@ -8670,13 +8670,13 @@
 		"terrainType": "LAND"
 	},
 	"45,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,13": {
 		"terrainType": "LAND"
@@ -8781,37 +8781,37 @@
 		"terrainType": "LAND"
 	},
 	"45,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,58": {
 		"terrainType": "LAND"
@@ -8826,10 +8826,10 @@
 		"terrainType": "LAND"
 	},
 	"45,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"45,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,0": {
 		"terrainType": "LAND"
@@ -8862,13 +8862,13 @@
 		"terrainType": "LAND"
 	},
 	"46,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,13": {
 		"terrainType": "LAND"
@@ -8928,25 +8928,25 @@
 		"terrainType": "LAND"
 	},
 	"46,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,39": {
 		"terrainType": "LAND"
@@ -8976,7 +8976,7 @@
 		"terrainType": "LAND"
 	},
 	"46,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,49": {
 		"terrainType": "LAND"
@@ -8985,25 +8985,25 @@
 		"terrainType": "LAND"
 	},
 	"46,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"46,58": {
 		"terrainType": "LAND"
@@ -9123,22 +9123,22 @@
 		"terrainType": "LAND"
 	},
 	"47,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,39": {
 		"terrainType": "LAND"
@@ -9183,19 +9183,19 @@
 		"terrainType": "LAND"
 	},
 	"47,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,54": {
 		"terrainType": "LAND"
 	},
 	"47,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"47,58": {
 		"terrainType": "LAND"
@@ -9381,13 +9381,13 @@
 		"terrainType": "LAND"
 	},
 	"48,55": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"48,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"48,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"48,58": {
 		"terrainType": "LAND"
@@ -9405,7 +9405,7 @@
 		"terrainType": "LAND"
 	},
 	"48,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,0": {
 		"terrainType": "LAND"
@@ -9468,16 +9468,16 @@
 		"terrainType": "LAND"
 	},
 	"49,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,22": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,23": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,24": {
 		"terrainType": "LAND"
@@ -9576,10 +9576,10 @@
 		"terrainType": "LAND"
 	},
 	"49,56": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,57": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,58": {
 		"terrainType": "LAND"
@@ -9594,10 +9594,10 @@
 		"terrainType": "LAND"
 	},
 	"49,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"49,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,0": {
 		"terrainType": "LAND"
@@ -9606,16 +9606,16 @@
 		"terrainType": "LAND"
 	},
 	"50,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,6": {
 		"terrainType": "LAND"
@@ -9660,19 +9660,19 @@
 		"terrainType": "LAND"
 	},
 	"50,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,22": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,23": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,24": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,25": {
 		"terrainType": "LAND"
@@ -9786,10 +9786,10 @@
 		"terrainType": "LAND"
 	},
 	"50,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"50,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,0": {
 		"terrainType": "LAND"
@@ -9798,19 +9798,19 @@
 		"terrainType": "LAND"
 	},
 	"51,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,7": {
 		"terrainType": "LAND"
@@ -9828,10 +9828,10 @@
 		"terrainType": "LAND"
 	},
 	"51,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,14": {
 		"terrainType": "LAND"
@@ -9846,25 +9846,25 @@
 		"terrainType": "LAND"
 	},
 	"51,18": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,19": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,22": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,23": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,24": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,25": {
 		"terrainType": "LAND"
@@ -9978,10 +9978,10 @@
 		"terrainType": "LAND"
 	},
 	"51,62": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"51,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,0": {
 		"terrainType": "LAND"
@@ -9990,19 +9990,19 @@
 		"terrainType": "LAND"
 	},
 	"52,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,7": {
 		"terrainType": "LAND"
@@ -10020,10 +10020,10 @@
 		"terrainType": "LAND"
 	},
 	"52,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,14": {
 		"terrainType": "LAND"
@@ -10038,16 +10038,16 @@
 		"terrainType": "LAND"
 	},
 	"52,18": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,19": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,20": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,21": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,22": {
 		"terrainType": "LAND"
@@ -10068,19 +10068,19 @@
 		"terrainType": "LAND"
 	},
 	"52,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,33": {
 		"terrainType": "LAND"
@@ -10110,13 +10110,13 @@
 		"terrainType": "LAND"
 	},
 	"52,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,44": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"52,45": {
 		"terrainType": "LAND"
@@ -10173,7 +10173,7 @@
 		"terrainType": "LAND"
 	},
 	"52,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,0": {
 		"terrainType": "LAND"
@@ -10182,16 +10182,16 @@
 		"terrainType": "LAND"
 	},
 	"53,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,4": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,5": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,6": {
 		"terrainType": "LAND"
@@ -10260,19 +10260,19 @@
 		"terrainType": "LAND"
 	},
 	"53,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,33": {
 		"terrainType": "LAND"
@@ -10302,19 +10302,19 @@
 		"terrainType": "LAND"
 	},
 	"53,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,44": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,45": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,46": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"53,47": {
 		"terrainType": "LAND"
@@ -10365,7 +10365,7 @@
 		"terrainType": "LAND"
 	},
 	"53,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,0": {
 		"terrainType": "LAND"
@@ -10374,10 +10374,10 @@
 		"terrainType": "LAND"
 	},
 	"54,2": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,3": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,4": {
 		"terrainType": "LAND"
@@ -10494,19 +10494,19 @@
 		"terrainType": "LAND"
 	},
 	"54,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,44": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,45": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,46": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"54,47": {
 		"terrainType": "LAND"
@@ -10557,7 +10557,7 @@
 		"terrainType": "LAND"
 	},
 	"54,63": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"55,0": {
 		"terrainType": "LAND"
@@ -10971,19 +10971,19 @@
 		"terrainType": "LAND"
 	},
 	"57,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"57,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"57,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"57,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"57,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"57,14": {
 		"terrainType": "LAND"
@@ -11157,25 +11157,25 @@
 		"terrainType": "LAND"
 	},
 	"58,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"58,14": {
 		"terrainType": "LAND"
@@ -11349,25 +11349,25 @@
 		"terrainType": "LAND"
 	},
 	"59,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,8": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,10": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,11": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,12": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,13": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"59,14": {
 		"terrainType": "LAND"
@@ -11598,37 +11598,37 @@
 		"terrainType": "LAND"
 	},
 	"60,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"60,37": {
 		"terrainType": "LAND"
@@ -11787,49 +11787,49 @@
 		"terrainType": "LAND"
 	},
 	"61,25": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"61,40": {
 		"terrainType": "LAND"
@@ -11922,16 +11922,16 @@
 		"terrainType": "LAND"
 	},
 	"62,6": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,7": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,8": {
 		"terrainType": "LAND"
 	},
 	"62,9": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,10": {
 		"terrainType": "LAND"
@@ -11979,94 +11979,94 @@
 		"terrainType": "LAND"
 	},
 	"62,25": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,42": {
 		"terrainType": "LAND"
 	},
 	"62,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,44": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,45": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,46": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"62,55": {
 		"terrainType": "LAND"
@@ -12165,100 +12165,100 @@
 		"terrainType": "LAND"
 	},
 	"63,23": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,24": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,25": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,26": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,27": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,28": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,29": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,30": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,31": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,32": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,33": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,34": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,35": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,36": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,37": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,38": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,39": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,40": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,41": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,42": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,43": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,44": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,45": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,46": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,47": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,48": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,49": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,50": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,51": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,52": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,53": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,54": {
-		"terrainType": "LAND"
+		"terrainType": "WATER"
 	},
 	"63,55": {
 		"terrainType": "LAND"

--- a/packages/client/src/const/tile.config.json
+++ b/packages/client/src/const/tile.config.json
@@ -1,0 +1,12290 @@
+{
+	"0,0": {
+		"terrainType": "LAND"
+	},
+	"0,1": {
+		"terrainType": "LAND"
+	},
+	"0,2": {
+		"terrainType": "LAND"
+	},
+	"0,3": {
+		"terrainType": "LAND"
+	},
+	"0,4": {
+		"terrainType": "LAND"
+	},
+	"0,5": {
+		"terrainType": "LAND"
+	},
+	"0,6": {
+		"terrainType": "LAND"
+	},
+	"0,7": {
+		"terrainType": "LAND"
+	},
+	"0,8": {
+		"terrainType": "LAND"
+	},
+	"0,9": {
+		"terrainType": "LAND"
+	},
+	"0,10": {
+		"terrainType": "LAND"
+	},
+	"0,11": {
+		"terrainType": "LAND"
+	},
+	"0,12": {
+		"terrainType": "LAND"
+	},
+	"0,13": {
+		"terrainType": "LAND"
+	},
+	"0,14": {
+		"terrainType": "LAND"
+	},
+	"0,15": {
+		"terrainType": "LAND"
+	},
+	"0,16": {
+		"terrainType": "LAND"
+	},
+	"0,17": {
+		"terrainType": "LAND"
+	},
+	"0,18": {
+		"terrainType": "LAND"
+	},
+	"0,19": {
+		"terrainType": "LAND"
+	},
+	"0,20": {
+		"terrainType": "LAND"
+	},
+	"0,21": {
+		"terrainType": "LAND"
+	},
+	"0,22": {
+		"terrainType": "LAND"
+	},
+	"0,23": {
+		"terrainType": "LAND"
+	},
+	"0,24": {
+		"terrainType": "LAND"
+	},
+	"0,25": {
+		"terrainType": "LAND"
+	},
+	"0,26": {
+		"terrainType": "LAND"
+	},
+	"0,27": {
+		"terrainType": "LAND"
+	},
+	"0,28": {
+		"terrainType": "LAND"
+	},
+	"0,29": {
+		"terrainType": "LAND"
+	},
+	"0,30": {
+		"terrainType": "LAND"
+	},
+	"0,31": {
+		"terrainType": "LAND"
+	},
+	"0,32": {
+		"terrainType": "LAND"
+	},
+	"0,33": {
+		"terrainType": "LAND"
+	},
+	"0,34": {
+		"terrainType": "LAND"
+	},
+	"0,35": {
+		"terrainType": "LAND"
+	},
+	"0,36": {
+		"terrainType": "LAND"
+	},
+	"0,37": {
+		"terrainType": "LAND"
+	},
+	"0,38": {
+		"terrainType": "LAND"
+	},
+	"0,39": {
+		"terrainType": "LAND"
+	},
+	"0,40": {
+		"terrainType": "LAND"
+	},
+	"0,41": {
+		"terrainType": "LAND"
+	},
+	"0,42": {
+		"terrainType": "LAND"
+	},
+	"0,43": {
+		"terrainType": "LAND"
+	},
+	"0,44": {
+		"terrainType": "LAND"
+	},
+	"0,45": {
+		"terrainType": "LAND"
+	},
+	"0,46": {
+		"terrainType": "LAND"
+	},
+	"0,47": {
+		"terrainType": "LAND"
+	},
+	"0,48": {
+		"terrainType": "LAND"
+	},
+	"0,49": {
+		"terrainType": "LAND"
+	},
+	"0,50": {
+		"terrainType": "LAND"
+	},
+	"0,51": {
+		"terrainType": "LAND"
+	},
+	"0,52": {
+		"terrainType": "LAND"
+	},
+	"0,53": {
+		"terrainType": "LAND"
+	},
+	"0,54": {
+		"terrainType": "LAND"
+	},
+	"0,55": {
+		"terrainType": "LAND"
+	},
+	"0,56": {
+		"terrainType": "LAND"
+	},
+	"0,57": {
+		"terrainType": "LAND"
+	},
+	"0,58": {
+		"terrainType": "LAND"
+	},
+	"0,59": {
+		"terrainType": "LAND"
+	},
+	"0,60": {
+		"terrainType": "LAND"
+	},
+	"0,61": {
+		"terrainType": "LAND"
+	},
+	"0,62": {
+		"terrainType": "LAND"
+	},
+	"0,63": {
+		"terrainType": "LAND"
+	},
+	"1,0": {
+		"terrainType": "LAND"
+	},
+	"1,1": {
+		"terrainType": "LAND"
+	},
+	"1,2": {
+		"terrainType": "LAND"
+	},
+	"1,3": {
+		"terrainType": "LAND"
+	},
+	"1,4": {
+		"terrainType": "LAND"
+	},
+	"1,5": {
+		"terrainType": "LAND"
+	},
+	"1,6": {
+		"terrainType": "LAND"
+	},
+	"1,7": {
+		"terrainType": "LAND"
+	},
+	"1,8": {
+		"terrainType": "LAND"
+	},
+	"1,9": {
+		"terrainType": "LAND"
+	},
+	"1,10": {
+		"terrainType": "LAND"
+	},
+	"1,11": {
+		"terrainType": "LAND"
+	},
+	"1,12": {
+		"terrainType": "LAND"
+	},
+	"1,13": {
+		"terrainType": "LAND"
+	},
+	"1,14": {
+		"terrainType": "LAND"
+	},
+	"1,15": {
+		"terrainType": "LAND"
+	},
+	"1,16": {
+		"terrainType": "LAND"
+	},
+	"1,17": {
+		"terrainType": "LAND"
+	},
+	"1,18": {
+		"terrainType": "LAND"
+	},
+	"1,19": {
+		"terrainType": "LAND"
+	},
+	"1,20": {
+		"terrainType": "LAND"
+	},
+	"1,21": {
+		"terrainType": "LAND"
+	},
+	"1,22": {
+		"terrainType": "LAND"
+	},
+	"1,23": {
+		"terrainType": "LAND"
+	},
+	"1,24": {
+		"terrainType": "LAND"
+	},
+	"1,25": {
+		"terrainType": "LAND"
+	},
+	"1,26": {
+		"terrainType": "LAND"
+	},
+	"1,27": {
+		"terrainType": "LAND"
+	},
+	"1,28": {
+		"terrainType": "LAND"
+	},
+	"1,29": {
+		"terrainType": "LAND"
+	},
+	"1,30": {
+		"terrainType": "LAND"
+	},
+	"1,31": {
+		"terrainType": "LAND"
+	},
+	"1,32": {
+		"terrainType": "LAND"
+	},
+	"1,33": {
+		"terrainType": "LAND"
+	},
+	"1,34": {
+		"terrainType": "LAND"
+	},
+	"1,35": {
+		"terrainType": "LAND"
+	},
+	"1,36": {
+		"terrainType": "LAND"
+	},
+	"1,37": {
+		"terrainType": "LAND"
+	},
+	"1,38": {
+		"terrainType": "LAND"
+	},
+	"1,39": {
+		"terrainType": "LAND"
+	},
+	"1,40": {
+		"terrainType": "LAND"
+	},
+	"1,41": {
+		"terrainType": "LAND"
+	},
+	"1,42": {
+		"terrainType": "LAND"
+	},
+	"1,43": {
+		"terrainType": "LAND"
+	},
+	"1,44": {
+		"terrainType": "LAND"
+	},
+	"1,45": {
+		"terrainType": "LAND"
+	},
+	"1,46": {
+		"terrainType": "LAND"
+	},
+	"1,47": {
+		"terrainType": "LAND"
+	},
+	"1,48": {
+		"terrainType": "LAND"
+	},
+	"1,49": {
+		"terrainType": "LAND"
+	},
+	"1,50": {
+		"terrainType": "LAND"
+	},
+	"1,51": {
+		"terrainType": "LAND"
+	},
+	"1,52": {
+		"terrainType": "LAND"
+	},
+	"1,53": {
+		"terrainType": "LAND"
+	},
+	"1,54": {
+		"terrainType": "LAND"
+	},
+	"1,55": {
+		"terrainType": "LAND"
+	},
+	"1,56": {
+		"terrainType": "LAND"
+	},
+	"1,57": {
+		"terrainType": "LAND"
+	},
+	"1,58": {
+		"terrainType": "LAND"
+	},
+	"1,59": {
+		"terrainType": "LAND"
+	},
+	"1,60": {
+		"terrainType": "LAND"
+	},
+	"1,61": {
+		"terrainType": "LAND"
+	},
+	"1,62": {
+		"terrainType": "LAND"
+	},
+	"1,63": {
+		"terrainType": "LAND"
+	},
+	"2,0": {
+		"terrainType": "LAND"
+	},
+	"2,1": {
+		"terrainType": "LAND"
+	},
+	"2,2": {
+		"terrainType": "LAND"
+	},
+	"2,3": {
+		"terrainType": "LAND"
+	},
+	"2,4": {
+		"terrainType": "LAND"
+	},
+	"2,5": {
+		"terrainType": "LAND"
+	},
+	"2,6": {
+		"terrainType": "LAND"
+	},
+	"2,7": {
+		"terrainType": "LAND"
+	},
+	"2,8": {
+		"terrainType": "LAND"
+	},
+	"2,9": {
+		"terrainType": "LAND"
+	},
+	"2,10": {
+		"terrainType": "LAND"
+	},
+	"2,11": {
+		"terrainType": "LAND"
+	},
+	"2,12": {
+		"terrainType": "LAND"
+	},
+	"2,13": {
+		"terrainType": "LAND"
+	},
+	"2,14": {
+		"terrainType": "LAND"
+	},
+	"2,15": {
+		"terrainType": "LAND"
+	},
+	"2,16": {
+		"terrainType": "LAND"
+	},
+	"2,17": {
+		"terrainType": "LAND"
+	},
+	"2,18": {
+		"terrainType": "LAND"
+	},
+	"2,19": {
+		"terrainType": "LAND"
+	},
+	"2,20": {
+		"terrainType": "LAND"
+	},
+	"2,21": {
+		"terrainType": "LAND"
+	},
+	"2,22": {
+		"terrainType": "LAND"
+	},
+	"2,23": {
+		"terrainType": "LAND"
+	},
+	"2,24": {
+		"terrainType": "LAND"
+	},
+	"2,25": {
+		"terrainType": "LAND"
+	},
+	"2,26": {
+		"terrainType": "LAND"
+	},
+	"2,27": {
+		"terrainType": "LAND"
+	},
+	"2,28": {
+		"terrainType": "LAND"
+	},
+	"2,29": {
+		"terrainType": "LAND"
+	},
+	"2,30": {
+		"terrainType": "LAND"
+	},
+	"2,31": {
+		"terrainType": "LAND"
+	},
+	"2,32": {
+		"terrainType": "LAND"
+	},
+	"2,33": {
+		"terrainType": "LAND"
+	},
+	"2,34": {
+		"terrainType": "LAND"
+	},
+	"2,35": {
+		"terrainType": "LAND"
+	},
+	"2,36": {
+		"terrainType": "LAND"
+	},
+	"2,37": {
+		"terrainType": "LAND"
+	},
+	"2,38": {
+		"terrainType": "LAND"
+	},
+	"2,39": {
+		"terrainType": "LAND"
+	},
+	"2,40": {
+		"terrainType": "LAND"
+	},
+	"2,41": {
+		"terrainType": "LAND"
+	},
+	"2,42": {
+		"terrainType": "LAND"
+	},
+	"2,43": {
+		"terrainType": "LAND"
+	},
+	"2,44": {
+		"terrainType": "LAND"
+	},
+	"2,45": {
+		"terrainType": "LAND"
+	},
+	"2,46": {
+		"terrainType": "LAND"
+	},
+	"2,47": {
+		"terrainType": "LAND"
+	},
+	"2,48": {
+		"terrainType": "LAND"
+	},
+	"2,49": {
+		"terrainType": "LAND"
+	},
+	"2,50": {
+		"terrainType": "LAND"
+	},
+	"2,51": {
+		"terrainType": "LAND"
+	},
+	"2,52": {
+		"terrainType": "LAND"
+	},
+	"2,53": {
+		"terrainType": "LAND"
+	},
+	"2,54": {
+		"terrainType": "LAND"
+	},
+	"2,55": {
+		"terrainType": "LAND"
+	},
+	"2,56": {
+		"terrainType": "LAND"
+	},
+	"2,57": {
+		"terrainType": "LAND"
+	},
+	"2,58": {
+		"terrainType": "LAND"
+	},
+	"2,59": {
+		"terrainType": "LAND"
+	},
+	"2,60": {
+		"terrainType": "LAND"
+	},
+	"2,61": {
+		"terrainType": "LAND"
+	},
+	"2,62": {
+		"terrainType": "LAND"
+	},
+	"2,63": {
+		"terrainType": "LAND"
+	},
+	"3,0": {
+		"terrainType": "LAND"
+	},
+	"3,1": {
+		"terrainType": "LAND"
+	},
+	"3,2": {
+		"terrainType": "LAND"
+	},
+	"3,3": {
+		"terrainType": "LAND"
+	},
+	"3,4": {
+		"terrainType": "LAND"
+	},
+	"3,5": {
+		"terrainType": "LAND"
+	},
+	"3,6": {
+		"terrainType": "LAND"
+	},
+	"3,7": {
+		"terrainType": "LAND"
+	},
+	"3,8": {
+		"terrainType": "LAND"
+	},
+	"3,9": {
+		"terrainType": "LAND"
+	},
+	"3,10": {
+		"terrainType": "LAND"
+	},
+	"3,11": {
+		"terrainType": "LAND"
+	},
+	"3,12": {
+		"terrainType": "LAND"
+	},
+	"3,13": {
+		"terrainType": "LAND"
+	},
+	"3,14": {
+		"terrainType": "LAND"
+	},
+	"3,15": {
+		"terrainType": "LAND"
+	},
+	"3,16": {
+		"terrainType": "LAND"
+	},
+	"3,17": {
+		"terrainType": "LAND"
+	},
+	"3,18": {
+		"terrainType": "LAND"
+	},
+	"3,19": {
+		"terrainType": "LAND"
+	},
+	"3,20": {
+		"terrainType": "LAND"
+	},
+	"3,21": {
+		"terrainType": "LAND"
+	},
+	"3,22": {
+		"terrainType": "LAND"
+	},
+	"3,23": {
+		"terrainType": "LAND"
+	},
+	"3,24": {
+		"terrainType": "LAND"
+	},
+	"3,25": {
+		"terrainType": "LAND"
+	},
+	"3,26": {
+		"terrainType": "LAND"
+	},
+	"3,27": {
+		"terrainType": "LAND"
+	},
+	"3,28": {
+		"terrainType": "LAND"
+	},
+	"3,29": {
+		"terrainType": "LAND"
+	},
+	"3,30": {
+		"terrainType": "LAND"
+	},
+	"3,31": {
+		"terrainType": "LAND"
+	},
+	"3,32": {
+		"terrainType": "LAND"
+	},
+	"3,33": {
+		"terrainType": "LAND"
+	},
+	"3,34": {
+		"terrainType": "LAND"
+	},
+	"3,35": {
+		"terrainType": "LAND"
+	},
+	"3,36": {
+		"terrainType": "LAND"
+	},
+	"3,37": {
+		"terrainType": "LAND"
+	},
+	"3,38": {
+		"terrainType": "LAND"
+	},
+	"3,39": {
+		"terrainType": "LAND"
+	},
+	"3,40": {
+		"terrainType": "LAND"
+	},
+	"3,41": {
+		"terrainType": "LAND"
+	},
+	"3,42": {
+		"terrainType": "LAND"
+	},
+	"3,43": {
+		"terrainType": "LAND"
+	},
+	"3,44": {
+		"terrainType": "LAND"
+	},
+	"3,45": {
+		"terrainType": "LAND"
+	},
+	"3,46": {
+		"terrainType": "LAND"
+	},
+	"3,47": {
+		"terrainType": "LAND"
+	},
+	"3,48": {
+		"terrainType": "LAND"
+	},
+	"3,49": {
+		"terrainType": "LAND"
+	},
+	"3,50": {
+		"terrainType": "LAND"
+	},
+	"3,51": {
+		"terrainType": "LAND"
+	},
+	"3,52": {
+		"terrainType": "LAND"
+	},
+	"3,53": {
+		"terrainType": "LAND"
+	},
+	"3,54": {
+		"terrainType": "LAND"
+	},
+	"3,55": {
+		"terrainType": "LAND"
+	},
+	"3,56": {
+		"terrainType": "LAND"
+	},
+	"3,57": {
+		"terrainType": "LAND"
+	},
+	"3,58": {
+		"terrainType": "LAND"
+	},
+	"3,59": {
+		"terrainType": "LAND"
+	},
+	"3,60": {
+		"terrainType": "LAND"
+	},
+	"3,61": {
+		"terrainType": "LAND"
+	},
+	"3,62": {
+		"terrainType": "LAND"
+	},
+	"3,63": {
+		"terrainType": "LAND"
+	},
+	"4,0": {
+		"terrainType": "LAND"
+	},
+	"4,1": {
+		"terrainType": "LAND"
+	},
+	"4,2": {
+		"terrainType": "LAND"
+	},
+	"4,3": {
+		"terrainType": "LAND"
+	},
+	"4,4": {
+		"terrainType": "LAND"
+	},
+	"4,5": {
+		"terrainType": "LAND"
+	},
+	"4,6": {
+		"terrainType": "LAND"
+	},
+	"4,7": {
+		"terrainType": "LAND"
+	},
+	"4,8": {
+		"terrainType": "LAND"
+	},
+	"4,9": {
+		"terrainType": "LAND"
+	},
+	"4,10": {
+		"terrainType": "LAND"
+	},
+	"4,11": {
+		"terrainType": "LAND"
+	},
+	"4,12": {
+		"terrainType": "LAND"
+	},
+	"4,13": {
+		"terrainType": "LAND"
+	},
+	"4,14": {
+		"terrainType": "LAND"
+	},
+	"4,15": {
+		"terrainType": "LAND"
+	},
+	"4,16": {
+		"terrainType": "LAND"
+	},
+	"4,17": {
+		"terrainType": "LAND"
+	},
+	"4,18": {
+		"terrainType": "LAND"
+	},
+	"4,19": {
+		"terrainType": "LAND"
+	},
+	"4,20": {
+		"terrainType": "LAND"
+	},
+	"4,21": {
+		"terrainType": "LAND"
+	},
+	"4,22": {
+		"terrainType": "LAND"
+	},
+	"4,23": {
+		"terrainType": "LAND"
+	},
+	"4,24": {
+		"terrainType": "LAND"
+	},
+	"4,25": {
+		"terrainType": "LAND"
+	},
+	"4,26": {
+		"terrainType": "LAND"
+	},
+	"4,27": {
+		"terrainType": "LAND"
+	},
+	"4,28": {
+		"terrainType": "LAND"
+	},
+	"4,29": {
+		"terrainType": "LAND"
+	},
+	"4,30": {
+		"terrainType": "LAND"
+	},
+	"4,31": {
+		"terrainType": "LAND"
+	},
+	"4,32": {
+		"terrainType": "LAND"
+	},
+	"4,33": {
+		"terrainType": "LAND"
+	},
+	"4,34": {
+		"terrainType": "LAND"
+	},
+	"4,35": {
+		"terrainType": "LAND"
+	},
+	"4,36": {
+		"terrainType": "LAND"
+	},
+	"4,37": {
+		"terrainType": "LAND"
+	},
+	"4,38": {
+		"terrainType": "LAND"
+	},
+	"4,39": {
+		"terrainType": "LAND"
+	},
+	"4,40": {
+		"terrainType": "LAND"
+	},
+	"4,41": {
+		"terrainType": "LAND"
+	},
+	"4,42": {
+		"terrainType": "LAND"
+	},
+	"4,43": {
+		"terrainType": "LAND"
+	},
+	"4,44": {
+		"terrainType": "LAND"
+	},
+	"4,45": {
+		"terrainType": "LAND"
+	},
+	"4,46": {
+		"terrainType": "LAND"
+	},
+	"4,47": {
+		"terrainType": "LAND"
+	},
+	"4,48": {
+		"terrainType": "LAND"
+	},
+	"4,49": {
+		"terrainType": "LAND"
+	},
+	"4,50": {
+		"terrainType": "LAND"
+	},
+	"4,51": {
+		"terrainType": "LAND"
+	},
+	"4,52": {
+		"terrainType": "LAND"
+	},
+	"4,53": {
+		"terrainType": "LAND"
+	},
+	"4,54": {
+		"terrainType": "LAND"
+	},
+	"4,55": {
+		"terrainType": "LAND"
+	},
+	"4,56": {
+		"terrainType": "LAND"
+	},
+	"4,57": {
+		"terrainType": "LAND"
+	},
+	"4,58": {
+		"terrainType": "LAND"
+	},
+	"4,59": {
+		"terrainType": "LAND"
+	},
+	"4,60": {
+		"terrainType": "LAND"
+	},
+	"4,61": {
+		"terrainType": "LAND"
+	},
+	"4,62": {
+		"terrainType": "LAND"
+	},
+	"4,63": {
+		"terrainType": "LAND"
+	},
+	"5,0": {
+		"terrainType": "LAND"
+	},
+	"5,1": {
+		"terrainType": "LAND"
+	},
+	"5,2": {
+		"terrainType": "LAND"
+	},
+	"5,3": {
+		"terrainType": "LAND"
+	},
+	"5,4": {
+		"terrainType": "LAND"
+	},
+	"5,5": {
+		"terrainType": "LAND"
+	},
+	"5,6": {
+		"terrainType": "LAND"
+	},
+	"5,7": {
+		"terrainType": "LAND"
+	},
+	"5,8": {
+		"terrainType": "LAND"
+	},
+	"5,9": {
+		"terrainType": "LAND"
+	},
+	"5,10": {
+		"terrainType": "LAND"
+	},
+	"5,11": {
+		"terrainType": "LAND"
+	},
+	"5,12": {
+		"terrainType": "LAND"
+	},
+	"5,13": {
+		"terrainType": "LAND"
+	},
+	"5,14": {
+		"terrainType": "LAND"
+	},
+	"5,15": {
+		"terrainType": "LAND"
+	},
+	"5,16": {
+		"terrainType": "LAND"
+	},
+	"5,17": {
+		"terrainType": "LAND"
+	},
+	"5,18": {
+		"terrainType": "LAND"
+	},
+	"5,19": {
+		"terrainType": "LAND"
+	},
+	"5,20": {
+		"terrainType": "LAND"
+	},
+	"5,21": {
+		"terrainType": "LAND"
+	},
+	"5,22": {
+		"terrainType": "LAND"
+	},
+	"5,23": {
+		"terrainType": "LAND"
+	},
+	"5,24": {
+		"terrainType": "LAND"
+	},
+	"5,25": {
+		"terrainType": "LAND"
+	},
+	"5,26": {
+		"terrainType": "LAND"
+	},
+	"5,27": {
+		"terrainType": "LAND"
+	},
+	"5,28": {
+		"terrainType": "LAND"
+	},
+	"5,29": {
+		"terrainType": "LAND"
+	},
+	"5,30": {
+		"terrainType": "LAND"
+	},
+	"5,31": {
+		"terrainType": "LAND"
+	},
+	"5,32": {
+		"terrainType": "LAND"
+	},
+	"5,33": {
+		"terrainType": "LAND"
+	},
+	"5,34": {
+		"terrainType": "LAND"
+	},
+	"5,35": {
+		"terrainType": "LAND"
+	},
+	"5,36": {
+		"terrainType": "LAND"
+	},
+	"5,37": {
+		"terrainType": "LAND"
+	},
+	"5,38": {
+		"terrainType": "LAND"
+	},
+	"5,39": {
+		"terrainType": "LAND"
+	},
+	"5,40": {
+		"terrainType": "LAND"
+	},
+	"5,41": {
+		"terrainType": "LAND"
+	},
+	"5,42": {
+		"terrainType": "LAND"
+	},
+	"5,43": {
+		"terrainType": "LAND"
+	},
+	"5,44": {
+		"terrainType": "LAND"
+	},
+	"5,45": {
+		"terrainType": "LAND"
+	},
+	"5,46": {
+		"terrainType": "LAND"
+	},
+	"5,47": {
+		"terrainType": "LAND"
+	},
+	"5,48": {
+		"terrainType": "LAND"
+	},
+	"5,49": {
+		"terrainType": "LAND"
+	},
+	"5,50": {
+		"terrainType": "LAND"
+	},
+	"5,51": {
+		"terrainType": "LAND"
+	},
+	"5,52": {
+		"terrainType": "LAND"
+	},
+	"5,53": {
+		"terrainType": "LAND"
+	},
+	"5,54": {
+		"terrainType": "LAND"
+	},
+	"5,55": {
+		"terrainType": "LAND"
+	},
+	"5,56": {
+		"terrainType": "LAND"
+	},
+	"5,57": {
+		"terrainType": "LAND"
+	},
+	"5,58": {
+		"terrainType": "LAND"
+	},
+	"5,59": {
+		"terrainType": "LAND"
+	},
+	"5,60": {
+		"terrainType": "LAND"
+	},
+	"5,61": {
+		"terrainType": "LAND"
+	},
+	"5,62": {
+		"terrainType": "LAND"
+	},
+	"5,63": {
+		"terrainType": "LAND"
+	},
+	"6,0": {
+		"terrainType": "LAND"
+	},
+	"6,1": {
+		"terrainType": "LAND"
+	},
+	"6,2": {
+		"terrainType": "LAND"
+	},
+	"6,3": {
+		"terrainType": "LAND"
+	},
+	"6,4": {
+		"terrainType": "LAND"
+	},
+	"6,5": {
+		"terrainType": "LAND"
+	},
+	"6,6": {
+		"terrainType": "LAND"
+	},
+	"6,7": {
+		"terrainType": "LAND"
+	},
+	"6,8": {
+		"terrainType": "LAND"
+	},
+	"6,9": {
+		"terrainType": "LAND"
+	},
+	"6,10": {
+		"terrainType": "LAND"
+	},
+	"6,11": {
+		"terrainType": "LAND"
+	},
+	"6,12": {
+		"terrainType": "LAND"
+	},
+	"6,13": {
+		"terrainType": "LAND"
+	},
+	"6,14": {
+		"terrainType": "LAND"
+	},
+	"6,15": {
+		"terrainType": "LAND"
+	},
+	"6,16": {
+		"terrainType": "LAND"
+	},
+	"6,17": {
+		"terrainType": "LAND"
+	},
+	"6,18": {
+		"terrainType": "LAND"
+	},
+	"6,19": {
+		"terrainType": "LAND"
+	},
+	"6,20": {
+		"terrainType": "LAND"
+	},
+	"6,21": {
+		"terrainType": "LAND"
+	},
+	"6,22": {
+		"terrainType": "LAND"
+	},
+	"6,23": {
+		"terrainType": "LAND"
+	},
+	"6,24": {
+		"terrainType": "LAND"
+	},
+	"6,25": {
+		"terrainType": "LAND"
+	},
+	"6,26": {
+		"terrainType": "LAND"
+	},
+	"6,27": {
+		"terrainType": "LAND"
+	},
+	"6,28": {
+		"terrainType": "LAND"
+	},
+	"6,29": {
+		"terrainType": "LAND"
+	},
+	"6,30": {
+		"terrainType": "LAND"
+	},
+	"6,31": {
+		"terrainType": "LAND"
+	},
+	"6,32": {
+		"terrainType": "LAND"
+	},
+	"6,33": {
+		"terrainType": "LAND"
+	},
+	"6,34": {
+		"terrainType": "LAND"
+	},
+	"6,35": {
+		"terrainType": "LAND"
+	},
+	"6,36": {
+		"terrainType": "LAND"
+	},
+	"6,37": {
+		"terrainType": "LAND"
+	},
+	"6,38": {
+		"terrainType": "LAND"
+	},
+	"6,39": {
+		"terrainType": "LAND"
+	},
+	"6,40": {
+		"terrainType": "LAND"
+	},
+	"6,41": {
+		"terrainType": "LAND"
+	},
+	"6,42": {
+		"terrainType": "LAND"
+	},
+	"6,43": {
+		"terrainType": "LAND"
+	},
+	"6,44": {
+		"terrainType": "LAND"
+	},
+	"6,45": {
+		"terrainType": "LAND"
+	},
+	"6,46": {
+		"terrainType": "LAND"
+	},
+	"6,47": {
+		"terrainType": "LAND"
+	},
+	"6,48": {
+		"terrainType": "LAND"
+	},
+	"6,49": {
+		"terrainType": "LAND"
+	},
+	"6,50": {
+		"terrainType": "LAND"
+	},
+	"6,51": {
+		"terrainType": "LAND"
+	},
+	"6,52": {
+		"terrainType": "LAND"
+	},
+	"6,53": {
+		"terrainType": "LAND"
+	},
+	"6,54": {
+		"terrainType": "LAND"
+	},
+	"6,55": {
+		"terrainType": "LAND"
+	},
+	"6,56": {
+		"terrainType": "LAND"
+	},
+	"6,57": {
+		"terrainType": "LAND"
+	},
+	"6,58": {
+		"terrainType": "LAND"
+	},
+	"6,59": {
+		"terrainType": "LAND"
+	},
+	"6,60": {
+		"terrainType": "LAND"
+	},
+	"6,61": {
+		"terrainType": "LAND"
+	},
+	"6,62": {
+		"terrainType": "LAND"
+	},
+	"6,63": {
+		"terrainType": "LAND"
+	},
+	"7,0": {
+		"terrainType": "LAND"
+	},
+	"7,1": {
+		"terrainType": "LAND"
+	},
+	"7,2": {
+		"terrainType": "LAND"
+	},
+	"7,3": {
+		"terrainType": "LAND"
+	},
+	"7,4": {
+		"terrainType": "LAND"
+	},
+	"7,5": {
+		"terrainType": "LAND"
+	},
+	"7,6": {
+		"terrainType": "LAND"
+	},
+	"7,7": {
+		"terrainType": "LAND"
+	},
+	"7,8": {
+		"terrainType": "LAND"
+	},
+	"7,9": {
+		"terrainType": "LAND"
+	},
+	"7,10": {
+		"terrainType": "LAND"
+	},
+	"7,11": {
+		"terrainType": "LAND"
+	},
+	"7,12": {
+		"terrainType": "LAND"
+	},
+	"7,13": {
+		"terrainType": "LAND"
+	},
+	"7,14": {
+		"terrainType": "LAND"
+	},
+	"7,15": {
+		"terrainType": "LAND"
+	},
+	"7,16": {
+		"terrainType": "LAND"
+	},
+	"7,17": {
+		"terrainType": "LAND"
+	},
+	"7,18": {
+		"terrainType": "LAND"
+	},
+	"7,19": {
+		"terrainType": "LAND"
+	},
+	"7,20": {
+		"terrainType": "LAND"
+	},
+	"7,21": {
+		"terrainType": "LAND"
+	},
+	"7,22": {
+		"terrainType": "LAND"
+	},
+	"7,23": {
+		"terrainType": "LAND"
+	},
+	"7,24": {
+		"terrainType": "LAND"
+	},
+	"7,25": {
+		"terrainType": "LAND"
+	},
+	"7,26": {
+		"terrainType": "LAND"
+	},
+	"7,27": {
+		"terrainType": "LAND"
+	},
+	"7,28": {
+		"terrainType": "LAND"
+	},
+	"7,29": {
+		"terrainType": "LAND"
+	},
+	"7,30": {
+		"terrainType": "LAND"
+	},
+	"7,31": {
+		"terrainType": "LAND"
+	},
+	"7,32": {
+		"terrainType": "LAND"
+	},
+	"7,33": {
+		"terrainType": "LAND"
+	},
+	"7,34": {
+		"terrainType": "LAND"
+	},
+	"7,35": {
+		"terrainType": "LAND"
+	},
+	"7,36": {
+		"terrainType": "LAND"
+	},
+	"7,37": {
+		"terrainType": "LAND"
+	},
+	"7,38": {
+		"terrainType": "LAND"
+	},
+	"7,39": {
+		"terrainType": "LAND"
+	},
+	"7,40": {
+		"terrainType": "LAND"
+	},
+	"7,41": {
+		"terrainType": "LAND"
+	},
+	"7,42": {
+		"terrainType": "LAND"
+	},
+	"7,43": {
+		"terrainType": "LAND"
+	},
+	"7,44": {
+		"terrainType": "LAND"
+	},
+	"7,45": {
+		"terrainType": "LAND"
+	},
+	"7,46": {
+		"terrainType": "LAND"
+	},
+	"7,47": {
+		"terrainType": "LAND"
+	},
+	"7,48": {
+		"terrainType": "LAND"
+	},
+	"7,49": {
+		"terrainType": "LAND"
+	},
+	"7,50": {
+		"terrainType": "LAND"
+	},
+	"7,51": {
+		"terrainType": "LAND"
+	},
+	"7,52": {
+		"terrainType": "LAND"
+	},
+	"7,53": {
+		"terrainType": "LAND"
+	},
+	"7,54": {
+		"terrainType": "LAND"
+	},
+	"7,55": {
+		"terrainType": "LAND"
+	},
+	"7,56": {
+		"terrainType": "LAND"
+	},
+	"7,57": {
+		"terrainType": "LAND"
+	},
+	"7,58": {
+		"terrainType": "LAND"
+	},
+	"7,59": {
+		"terrainType": "LAND"
+	},
+	"7,60": {
+		"terrainType": "LAND"
+	},
+	"7,61": {
+		"terrainType": "LAND"
+	},
+	"7,62": {
+		"terrainType": "LAND"
+	},
+	"7,63": {
+		"terrainType": "LAND"
+	},
+	"8,0": {
+		"terrainType": "LAND"
+	},
+	"8,1": {
+		"terrainType": "LAND"
+	},
+	"8,2": {
+		"terrainType": "LAND"
+	},
+	"8,3": {
+		"terrainType": "LAND"
+	},
+	"8,4": {
+		"terrainType": "LAND"
+	},
+	"8,5": {
+		"terrainType": "LAND"
+	},
+	"8,6": {
+		"terrainType": "LAND"
+	},
+	"8,7": {
+		"terrainType": "LAND"
+	},
+	"8,8": {
+		"terrainType": "LAND"
+	},
+	"8,9": {
+		"terrainType": "LAND"
+	},
+	"8,10": {
+		"terrainType": "LAND"
+	},
+	"8,11": {
+		"terrainType": "LAND"
+	},
+	"8,12": {
+		"terrainType": "LAND"
+	},
+	"8,13": {
+		"terrainType": "LAND"
+	},
+	"8,14": {
+		"terrainType": "LAND"
+	},
+	"8,15": {
+		"terrainType": "LAND"
+	},
+	"8,16": {
+		"terrainType": "LAND"
+	},
+	"8,17": {
+		"terrainType": "LAND"
+	},
+	"8,18": {
+		"terrainType": "LAND"
+	},
+	"8,19": {
+		"terrainType": "LAND"
+	},
+	"8,20": {
+		"terrainType": "LAND"
+	},
+	"8,21": {
+		"terrainType": "LAND"
+	},
+	"8,22": {
+		"terrainType": "LAND"
+	},
+	"8,23": {
+		"terrainType": "LAND"
+	},
+	"8,24": {
+		"terrainType": "LAND"
+	},
+	"8,25": {
+		"terrainType": "LAND"
+	},
+	"8,26": {
+		"terrainType": "LAND"
+	},
+	"8,27": {
+		"terrainType": "LAND"
+	},
+	"8,28": {
+		"terrainType": "LAND"
+	},
+	"8,29": {
+		"terrainType": "LAND"
+	},
+	"8,30": {
+		"terrainType": "LAND"
+	},
+	"8,31": {
+		"terrainType": "LAND"
+	},
+	"8,32": {
+		"terrainType": "LAND"
+	},
+	"8,33": {
+		"terrainType": "LAND"
+	},
+	"8,34": {
+		"terrainType": "LAND"
+	},
+	"8,35": {
+		"terrainType": "LAND"
+	},
+	"8,36": {
+		"terrainType": "LAND"
+	},
+	"8,37": {
+		"terrainType": "LAND"
+	},
+	"8,38": {
+		"terrainType": "LAND"
+	},
+	"8,39": {
+		"terrainType": "LAND"
+	},
+	"8,40": {
+		"terrainType": "LAND"
+	},
+	"8,41": {
+		"terrainType": "LAND"
+	},
+	"8,42": {
+		"terrainType": "LAND"
+	},
+	"8,43": {
+		"terrainType": "LAND"
+	},
+	"8,44": {
+		"terrainType": "LAND"
+	},
+	"8,45": {
+		"terrainType": "LAND"
+	},
+	"8,46": {
+		"terrainType": "LAND"
+	},
+	"8,47": {
+		"terrainType": "LAND"
+	},
+	"8,48": {
+		"terrainType": "LAND"
+	},
+	"8,49": {
+		"terrainType": "LAND"
+	},
+	"8,50": {
+		"terrainType": "LAND"
+	},
+	"8,51": {
+		"terrainType": "LAND"
+	},
+	"8,52": {
+		"terrainType": "LAND"
+	},
+	"8,53": {
+		"terrainType": "LAND"
+	},
+	"8,54": {
+		"terrainType": "LAND"
+	},
+	"8,55": {
+		"terrainType": "LAND"
+	},
+	"8,56": {
+		"terrainType": "LAND"
+	},
+	"8,57": {
+		"terrainType": "LAND"
+	},
+	"8,58": {
+		"terrainType": "LAND"
+	},
+	"8,59": {
+		"terrainType": "LAND"
+	},
+	"8,60": {
+		"terrainType": "LAND"
+	},
+	"8,61": {
+		"terrainType": "LAND"
+	},
+	"8,62": {
+		"terrainType": "LAND"
+	},
+	"8,63": {
+		"terrainType": "LAND"
+	},
+	"9,0": {
+		"terrainType": "LAND"
+	},
+	"9,1": {
+		"terrainType": "LAND"
+	},
+	"9,2": {
+		"terrainType": "LAND"
+	},
+	"9,3": {
+		"terrainType": "LAND"
+	},
+	"9,4": {
+		"terrainType": "LAND"
+	},
+	"9,5": {
+		"terrainType": "LAND"
+	},
+	"9,6": {
+		"terrainType": "LAND"
+	},
+	"9,7": {
+		"terrainType": "LAND"
+	},
+	"9,8": {
+		"terrainType": "LAND"
+	},
+	"9,9": {
+		"terrainType": "LAND"
+	},
+	"9,10": {
+		"terrainType": "LAND"
+	},
+	"9,11": {
+		"terrainType": "LAND"
+	},
+	"9,12": {
+		"terrainType": "LAND"
+	},
+	"9,13": {
+		"terrainType": "LAND"
+	},
+	"9,14": {
+		"terrainType": "LAND"
+	},
+	"9,15": {
+		"terrainType": "LAND"
+	},
+	"9,16": {
+		"terrainType": "LAND"
+	},
+	"9,17": {
+		"terrainType": "LAND"
+	},
+	"9,18": {
+		"terrainType": "LAND"
+	},
+	"9,19": {
+		"terrainType": "LAND"
+	},
+	"9,20": {
+		"terrainType": "LAND"
+	},
+	"9,21": {
+		"terrainType": "LAND"
+	},
+	"9,22": {
+		"terrainType": "LAND"
+	},
+	"9,23": {
+		"terrainType": "LAND"
+	},
+	"9,24": {
+		"terrainType": "LAND"
+	},
+	"9,25": {
+		"terrainType": "LAND"
+	},
+	"9,26": {
+		"terrainType": "LAND"
+	},
+	"9,27": {
+		"terrainType": "LAND"
+	},
+	"9,28": {
+		"terrainType": "LAND"
+	},
+	"9,29": {
+		"terrainType": "LAND"
+	},
+	"9,30": {
+		"terrainType": "LAND"
+	},
+	"9,31": {
+		"terrainType": "LAND"
+	},
+	"9,32": {
+		"terrainType": "LAND"
+	},
+	"9,33": {
+		"terrainType": "LAND"
+	},
+	"9,34": {
+		"terrainType": "LAND"
+	},
+	"9,35": {
+		"terrainType": "LAND"
+	},
+	"9,36": {
+		"terrainType": "LAND"
+	},
+	"9,37": {
+		"terrainType": "LAND"
+	},
+	"9,38": {
+		"terrainType": "LAND"
+	},
+	"9,39": {
+		"terrainType": "LAND"
+	},
+	"9,40": {
+		"terrainType": "LAND"
+	},
+	"9,41": {
+		"terrainType": "LAND"
+	},
+	"9,42": {
+		"terrainType": "LAND"
+	},
+	"9,43": {
+		"terrainType": "LAND"
+	},
+	"9,44": {
+		"terrainType": "LAND"
+	},
+	"9,45": {
+		"terrainType": "LAND"
+	},
+	"9,46": {
+		"terrainType": "LAND"
+	},
+	"9,47": {
+		"terrainType": "LAND"
+	},
+	"9,48": {
+		"terrainType": "LAND"
+	},
+	"9,49": {
+		"terrainType": "LAND"
+	},
+	"9,50": {
+		"terrainType": "LAND"
+	},
+	"9,51": {
+		"terrainType": "LAND"
+	},
+	"9,52": {
+		"terrainType": "LAND"
+	},
+	"9,53": {
+		"terrainType": "LAND"
+	},
+	"9,54": {
+		"terrainType": "LAND"
+	},
+	"9,55": {
+		"terrainType": "LAND"
+	},
+	"9,56": {
+		"terrainType": "LAND"
+	},
+	"9,57": {
+		"terrainType": "LAND"
+	},
+	"9,58": {
+		"terrainType": "LAND"
+	},
+	"9,59": {
+		"terrainType": "LAND"
+	},
+	"9,60": {
+		"terrainType": "LAND"
+	},
+	"9,61": {
+		"terrainType": "LAND"
+	},
+	"9,62": {
+		"terrainType": "LAND"
+	},
+	"9,63": {
+		"terrainType": "LAND"
+	},
+	"10,0": {
+		"terrainType": "LAND"
+	},
+	"10,1": {
+		"terrainType": "LAND"
+	},
+	"10,2": {
+		"terrainType": "LAND"
+	},
+	"10,3": {
+		"terrainType": "LAND"
+	},
+	"10,4": {
+		"terrainType": "LAND"
+	},
+	"10,5": {
+		"terrainType": "LAND"
+	},
+	"10,6": {
+		"terrainType": "LAND"
+	},
+	"10,7": {
+		"terrainType": "LAND"
+	},
+	"10,8": {
+		"terrainType": "LAND"
+	},
+	"10,9": {
+		"terrainType": "LAND"
+	},
+	"10,10": {
+		"terrainType": "LAND"
+	},
+	"10,11": {
+		"terrainType": "LAND"
+	},
+	"10,12": {
+		"terrainType": "LAND"
+	},
+	"10,13": {
+		"terrainType": "LAND"
+	},
+	"10,14": {
+		"terrainType": "LAND"
+	},
+	"10,15": {
+		"terrainType": "LAND"
+	},
+	"10,16": {
+		"terrainType": "LAND"
+	},
+	"10,17": {
+		"terrainType": "LAND"
+	},
+	"10,18": {
+		"terrainType": "LAND"
+	},
+	"10,19": {
+		"terrainType": "LAND"
+	},
+	"10,20": {
+		"terrainType": "LAND"
+	},
+	"10,21": {
+		"terrainType": "LAND"
+	},
+	"10,22": {
+		"terrainType": "LAND"
+	},
+	"10,23": {
+		"terrainType": "LAND"
+	},
+	"10,24": {
+		"terrainType": "LAND"
+	},
+	"10,25": {
+		"terrainType": "LAND"
+	},
+	"10,26": {
+		"terrainType": "LAND"
+	},
+	"10,27": {
+		"terrainType": "LAND"
+	},
+	"10,28": {
+		"terrainType": "LAND"
+	},
+	"10,29": {
+		"terrainType": "LAND"
+	},
+	"10,30": {
+		"terrainType": "LAND"
+	},
+	"10,31": {
+		"terrainType": "LAND"
+	},
+	"10,32": {
+		"terrainType": "LAND"
+	},
+	"10,33": {
+		"terrainType": "LAND"
+	},
+	"10,34": {
+		"terrainType": "LAND"
+	},
+	"10,35": {
+		"terrainType": "LAND"
+	},
+	"10,36": {
+		"terrainType": "LAND"
+	},
+	"10,37": {
+		"terrainType": "LAND"
+	},
+	"10,38": {
+		"terrainType": "LAND"
+	},
+	"10,39": {
+		"terrainType": "LAND"
+	},
+	"10,40": {
+		"terrainType": "LAND"
+	},
+	"10,41": {
+		"terrainType": "LAND"
+	},
+	"10,42": {
+		"terrainType": "LAND"
+	},
+	"10,43": {
+		"terrainType": "LAND"
+	},
+	"10,44": {
+		"terrainType": "LAND"
+	},
+	"10,45": {
+		"terrainType": "LAND"
+	},
+	"10,46": {
+		"terrainType": "LAND"
+	},
+	"10,47": {
+		"terrainType": "LAND"
+	},
+	"10,48": {
+		"terrainType": "LAND"
+	},
+	"10,49": {
+		"terrainType": "LAND"
+	},
+	"10,50": {
+		"terrainType": "LAND"
+	},
+	"10,51": {
+		"terrainType": "LAND"
+	},
+	"10,52": {
+		"terrainType": "LAND"
+	},
+	"10,53": {
+		"terrainType": "LAND"
+	},
+	"10,54": {
+		"terrainType": "LAND"
+	},
+	"10,55": {
+		"terrainType": "LAND"
+	},
+	"10,56": {
+		"terrainType": "LAND"
+	},
+	"10,57": {
+		"terrainType": "LAND"
+	},
+	"10,58": {
+		"terrainType": "LAND"
+	},
+	"10,59": {
+		"terrainType": "LAND"
+	},
+	"10,60": {
+		"terrainType": "LAND"
+	},
+	"10,61": {
+		"terrainType": "LAND"
+	},
+	"10,62": {
+		"terrainType": "LAND"
+	},
+	"10,63": {
+		"terrainType": "LAND"
+	},
+	"11,0": {
+		"terrainType": "LAND"
+	},
+	"11,1": {
+		"terrainType": "LAND"
+	},
+	"11,2": {
+		"terrainType": "LAND"
+	},
+	"11,3": {
+		"terrainType": "LAND"
+	},
+	"11,4": {
+		"terrainType": "LAND"
+	},
+	"11,5": {
+		"terrainType": "LAND"
+	},
+	"11,6": {
+		"terrainType": "LAND"
+	},
+	"11,7": {
+		"terrainType": "LAND"
+	},
+	"11,8": {
+		"terrainType": "LAND"
+	},
+	"11,9": {
+		"terrainType": "LAND"
+	},
+	"11,10": {
+		"terrainType": "LAND"
+	},
+	"11,11": {
+		"terrainType": "LAND"
+	},
+	"11,12": {
+		"terrainType": "LAND"
+	},
+	"11,13": {
+		"terrainType": "LAND"
+	},
+	"11,14": {
+		"terrainType": "LAND"
+	},
+	"11,15": {
+		"terrainType": "LAND"
+	},
+	"11,16": {
+		"terrainType": "LAND"
+	},
+	"11,17": {
+		"terrainType": "LAND"
+	},
+	"11,18": {
+		"terrainType": "LAND"
+	},
+	"11,19": {
+		"terrainType": "LAND"
+	},
+	"11,20": {
+		"terrainType": "LAND"
+	},
+	"11,21": {
+		"terrainType": "LAND"
+	},
+	"11,22": {
+		"terrainType": "LAND"
+	},
+	"11,23": {
+		"terrainType": "LAND"
+	},
+	"11,24": {
+		"terrainType": "LAND"
+	},
+	"11,25": {
+		"terrainType": "LAND"
+	},
+	"11,26": {
+		"terrainType": "LAND"
+	},
+	"11,27": {
+		"terrainType": "LAND"
+	},
+	"11,28": {
+		"terrainType": "LAND"
+	},
+	"11,29": {
+		"terrainType": "LAND"
+	},
+	"11,30": {
+		"terrainType": "LAND"
+	},
+	"11,31": {
+		"terrainType": "LAND"
+	},
+	"11,32": {
+		"terrainType": "LAND"
+	},
+	"11,33": {
+		"terrainType": "LAND"
+	},
+	"11,34": {
+		"terrainType": "LAND"
+	},
+	"11,35": {
+		"terrainType": "LAND"
+	},
+	"11,36": {
+		"terrainType": "LAND"
+	},
+	"11,37": {
+		"terrainType": "LAND"
+	},
+	"11,38": {
+		"terrainType": "LAND"
+	},
+	"11,39": {
+		"terrainType": "LAND"
+	},
+	"11,40": {
+		"terrainType": "LAND"
+	},
+	"11,41": {
+		"terrainType": "LAND"
+	},
+	"11,42": {
+		"terrainType": "LAND"
+	},
+	"11,43": {
+		"terrainType": "LAND"
+	},
+	"11,44": {
+		"terrainType": "LAND"
+	},
+	"11,45": {
+		"terrainType": "LAND"
+	},
+	"11,46": {
+		"terrainType": "LAND"
+	},
+	"11,47": {
+		"terrainType": "LAND"
+	},
+	"11,48": {
+		"terrainType": "LAND"
+	},
+	"11,49": {
+		"terrainType": "LAND"
+	},
+	"11,50": {
+		"terrainType": "LAND"
+	},
+	"11,51": {
+		"terrainType": "LAND"
+	},
+	"11,52": {
+		"terrainType": "LAND"
+	},
+	"11,53": {
+		"terrainType": "LAND"
+	},
+	"11,54": {
+		"terrainType": "LAND"
+	},
+	"11,55": {
+		"terrainType": "LAND"
+	},
+	"11,56": {
+		"terrainType": "LAND"
+	},
+	"11,57": {
+		"terrainType": "LAND"
+	},
+	"11,58": {
+		"terrainType": "LAND"
+	},
+	"11,59": {
+		"terrainType": "LAND"
+	},
+	"11,60": {
+		"terrainType": "LAND"
+	},
+	"11,61": {
+		"terrainType": "LAND"
+	},
+	"11,62": {
+		"terrainType": "LAND"
+	},
+	"11,63": {
+		"terrainType": "LAND"
+	},
+	"12,0": {
+		"terrainType": "LAND"
+	},
+	"12,1": {
+		"terrainType": "LAND"
+	},
+	"12,2": {
+		"terrainType": "LAND"
+	},
+	"12,3": {
+		"terrainType": "LAND"
+	},
+	"12,4": {
+		"terrainType": "LAND"
+	},
+	"12,5": {
+		"terrainType": "LAND"
+	},
+	"12,6": {
+		"terrainType": "LAND"
+	},
+	"12,7": {
+		"terrainType": "LAND"
+	},
+	"12,8": {
+		"terrainType": "LAND"
+	},
+	"12,9": {
+		"terrainType": "LAND"
+	},
+	"12,10": {
+		"terrainType": "LAND"
+	},
+	"12,11": {
+		"terrainType": "LAND"
+	},
+	"12,12": {
+		"terrainType": "LAND"
+	},
+	"12,13": {
+		"terrainType": "LAND"
+	},
+	"12,14": {
+		"terrainType": "LAND"
+	},
+	"12,15": {
+		"terrainType": "LAND"
+	},
+	"12,16": {
+		"terrainType": "LAND"
+	},
+	"12,17": {
+		"terrainType": "LAND"
+	},
+	"12,18": {
+		"terrainType": "LAND"
+	},
+	"12,19": {
+		"terrainType": "LAND"
+	},
+	"12,20": {
+		"terrainType": "LAND"
+	},
+	"12,21": {
+		"terrainType": "LAND"
+	},
+	"12,22": {
+		"terrainType": "LAND"
+	},
+	"12,23": {
+		"terrainType": "LAND"
+	},
+	"12,24": {
+		"terrainType": "LAND"
+	},
+	"12,25": {
+		"terrainType": "LAND"
+	},
+	"12,26": {
+		"terrainType": "LAND"
+	},
+	"12,27": {
+		"terrainType": "LAND"
+	},
+	"12,28": {
+		"terrainType": "LAND"
+	},
+	"12,29": {
+		"terrainType": "LAND"
+	},
+	"12,30": {
+		"terrainType": "LAND"
+	},
+	"12,31": {
+		"terrainType": "LAND"
+	},
+	"12,32": {
+		"terrainType": "LAND"
+	},
+	"12,33": {
+		"terrainType": "LAND"
+	},
+	"12,34": {
+		"terrainType": "LAND"
+	},
+	"12,35": {
+		"terrainType": "LAND"
+	},
+	"12,36": {
+		"terrainType": "LAND"
+	},
+	"12,37": {
+		"terrainType": "LAND"
+	},
+	"12,38": {
+		"terrainType": "LAND"
+	},
+	"12,39": {
+		"terrainType": "LAND"
+	},
+	"12,40": {
+		"terrainType": "LAND"
+	},
+	"12,41": {
+		"terrainType": "LAND"
+	},
+	"12,42": {
+		"terrainType": "LAND"
+	},
+	"12,43": {
+		"terrainType": "LAND"
+	},
+	"12,44": {
+		"terrainType": "LAND"
+	},
+	"12,45": {
+		"terrainType": "LAND"
+	},
+	"12,46": {
+		"terrainType": "LAND"
+	},
+	"12,47": {
+		"terrainType": "LAND"
+	},
+	"12,48": {
+		"terrainType": "LAND"
+	},
+	"12,49": {
+		"terrainType": "LAND"
+	},
+	"12,50": {
+		"terrainType": "LAND"
+	},
+	"12,51": {
+		"terrainType": "LAND"
+	},
+	"12,52": {
+		"terrainType": "LAND"
+	},
+	"12,53": {
+		"terrainType": "LAND"
+	},
+	"12,54": {
+		"terrainType": "LAND"
+	},
+	"12,55": {
+		"terrainType": "LAND"
+	},
+	"12,56": {
+		"terrainType": "LAND"
+	},
+	"12,57": {
+		"terrainType": "LAND"
+	},
+	"12,58": {
+		"terrainType": "LAND"
+	},
+	"12,59": {
+		"terrainType": "LAND"
+	},
+	"12,60": {
+		"terrainType": "LAND"
+	},
+	"12,61": {
+		"terrainType": "LAND"
+	},
+	"12,62": {
+		"terrainType": "LAND"
+	},
+	"12,63": {
+		"terrainType": "LAND"
+	},
+	"13,0": {
+		"terrainType": "LAND"
+	},
+	"13,1": {
+		"terrainType": "LAND"
+	},
+	"13,2": {
+		"terrainType": "LAND"
+	},
+	"13,3": {
+		"terrainType": "LAND"
+	},
+	"13,4": {
+		"terrainType": "LAND"
+	},
+	"13,5": {
+		"terrainType": "LAND"
+	},
+	"13,6": {
+		"terrainType": "LAND"
+	},
+	"13,7": {
+		"terrainType": "LAND"
+	},
+	"13,8": {
+		"terrainType": "LAND"
+	},
+	"13,9": {
+		"terrainType": "LAND"
+	},
+	"13,10": {
+		"terrainType": "LAND"
+	},
+	"13,11": {
+		"terrainType": "LAND"
+	},
+	"13,12": {
+		"terrainType": "LAND"
+	},
+	"13,13": {
+		"terrainType": "LAND"
+	},
+	"13,14": {
+		"terrainType": "LAND"
+	},
+	"13,15": {
+		"terrainType": "LAND"
+	},
+	"13,16": {
+		"terrainType": "LAND"
+	},
+	"13,17": {
+		"terrainType": "LAND"
+	},
+	"13,18": {
+		"terrainType": "LAND"
+	},
+	"13,19": {
+		"terrainType": "LAND"
+	},
+	"13,20": {
+		"terrainType": "LAND"
+	},
+	"13,21": {
+		"terrainType": "LAND"
+	},
+	"13,22": {
+		"terrainType": "LAND"
+	},
+	"13,23": {
+		"terrainType": "LAND"
+	},
+	"13,24": {
+		"terrainType": "LAND"
+	},
+	"13,25": {
+		"terrainType": "LAND"
+	},
+	"13,26": {
+		"terrainType": "LAND"
+	},
+	"13,27": {
+		"terrainType": "LAND"
+	},
+	"13,28": {
+		"terrainType": "LAND"
+	},
+	"13,29": {
+		"terrainType": "LAND"
+	},
+	"13,30": {
+		"terrainType": "LAND"
+	},
+	"13,31": {
+		"terrainType": "LAND"
+	},
+	"13,32": {
+		"terrainType": "LAND"
+	},
+	"13,33": {
+		"terrainType": "LAND"
+	},
+	"13,34": {
+		"terrainType": "LAND"
+	},
+	"13,35": {
+		"terrainType": "LAND"
+	},
+	"13,36": {
+		"terrainType": "LAND"
+	},
+	"13,37": {
+		"terrainType": "LAND"
+	},
+	"13,38": {
+		"terrainType": "LAND"
+	},
+	"13,39": {
+		"terrainType": "LAND"
+	},
+	"13,40": {
+		"terrainType": "LAND"
+	},
+	"13,41": {
+		"terrainType": "LAND"
+	},
+	"13,42": {
+		"terrainType": "LAND"
+	},
+	"13,43": {
+		"terrainType": "LAND"
+	},
+	"13,44": {
+		"terrainType": "LAND"
+	},
+	"13,45": {
+		"terrainType": "LAND"
+	},
+	"13,46": {
+		"terrainType": "LAND"
+	},
+	"13,47": {
+		"terrainType": "LAND"
+	},
+	"13,48": {
+		"terrainType": "LAND"
+	},
+	"13,49": {
+		"terrainType": "LAND"
+	},
+	"13,50": {
+		"terrainType": "LAND"
+	},
+	"13,51": {
+		"terrainType": "LAND"
+	},
+	"13,52": {
+		"terrainType": "LAND"
+	},
+	"13,53": {
+		"terrainType": "LAND"
+	},
+	"13,54": {
+		"terrainType": "LAND"
+	},
+	"13,55": {
+		"terrainType": "LAND"
+	},
+	"13,56": {
+		"terrainType": "LAND"
+	},
+	"13,57": {
+		"terrainType": "LAND"
+	},
+	"13,58": {
+		"terrainType": "LAND"
+	},
+	"13,59": {
+		"terrainType": "LAND"
+	},
+	"13,60": {
+		"terrainType": "LAND"
+	},
+	"13,61": {
+		"terrainType": "LAND"
+	},
+	"13,62": {
+		"terrainType": "LAND"
+	},
+	"13,63": {
+		"terrainType": "LAND"
+	},
+	"14,0": {
+		"terrainType": "LAND"
+	},
+	"14,1": {
+		"terrainType": "LAND"
+	},
+	"14,2": {
+		"terrainType": "LAND"
+	},
+	"14,3": {
+		"terrainType": "LAND"
+	},
+	"14,4": {
+		"terrainType": "LAND"
+	},
+	"14,5": {
+		"terrainType": "LAND"
+	},
+	"14,6": {
+		"terrainType": "LAND"
+	},
+	"14,7": {
+		"terrainType": "LAND"
+	},
+	"14,8": {
+		"terrainType": "LAND"
+	},
+	"14,9": {
+		"terrainType": "LAND"
+	},
+	"14,10": {
+		"terrainType": "LAND"
+	},
+	"14,11": {
+		"terrainType": "LAND"
+	},
+	"14,12": {
+		"terrainType": "LAND"
+	},
+	"14,13": {
+		"terrainType": "LAND"
+	},
+	"14,14": {
+		"terrainType": "LAND"
+	},
+	"14,15": {
+		"terrainType": "LAND"
+	},
+	"14,16": {
+		"terrainType": "LAND"
+	},
+	"14,17": {
+		"terrainType": "LAND"
+	},
+	"14,18": {
+		"terrainType": "LAND"
+	},
+	"14,19": {
+		"terrainType": "LAND"
+	},
+	"14,20": {
+		"terrainType": "LAND"
+	},
+	"14,21": {
+		"terrainType": "LAND"
+	},
+	"14,22": {
+		"terrainType": "LAND"
+	},
+	"14,23": {
+		"terrainType": "LAND"
+	},
+	"14,24": {
+		"terrainType": "LAND"
+	},
+	"14,25": {
+		"terrainType": "LAND"
+	},
+	"14,26": {
+		"terrainType": "LAND"
+	},
+	"14,27": {
+		"terrainType": "LAND"
+	},
+	"14,28": {
+		"terrainType": "LAND"
+	},
+	"14,29": {
+		"terrainType": "LAND"
+	},
+	"14,30": {
+		"terrainType": "LAND"
+	},
+	"14,31": {
+		"terrainType": "LAND"
+	},
+	"14,32": {
+		"terrainType": "LAND"
+	},
+	"14,33": {
+		"terrainType": "LAND"
+	},
+	"14,34": {
+		"terrainType": "LAND"
+	},
+	"14,35": {
+		"terrainType": "LAND"
+	},
+	"14,36": {
+		"terrainType": "LAND"
+	},
+	"14,37": {
+		"terrainType": "LAND"
+	},
+	"14,38": {
+		"terrainType": "LAND"
+	},
+	"14,39": {
+		"terrainType": "LAND"
+	},
+	"14,40": {
+		"terrainType": "LAND"
+	},
+	"14,41": {
+		"terrainType": "LAND"
+	},
+	"14,42": {
+		"terrainType": "LAND"
+	},
+	"14,43": {
+		"terrainType": "LAND"
+	},
+	"14,44": {
+		"terrainType": "LAND"
+	},
+	"14,45": {
+		"terrainType": "LAND"
+	},
+	"14,46": {
+		"terrainType": "LAND"
+	},
+	"14,47": {
+		"terrainType": "LAND"
+	},
+	"14,48": {
+		"terrainType": "LAND"
+	},
+	"14,49": {
+		"terrainType": "LAND"
+	},
+	"14,50": {
+		"terrainType": "LAND"
+	},
+	"14,51": {
+		"terrainType": "LAND"
+	},
+	"14,52": {
+		"terrainType": "LAND"
+	},
+	"14,53": {
+		"terrainType": "LAND"
+	},
+	"14,54": {
+		"terrainType": "LAND"
+	},
+	"14,55": {
+		"terrainType": "LAND"
+	},
+	"14,56": {
+		"terrainType": "LAND"
+	},
+	"14,57": {
+		"terrainType": "LAND"
+	},
+	"14,58": {
+		"terrainType": "LAND"
+	},
+	"14,59": {
+		"terrainType": "LAND"
+	},
+	"14,60": {
+		"terrainType": "LAND"
+	},
+	"14,61": {
+		"terrainType": "LAND"
+	},
+	"14,62": {
+		"terrainType": "LAND"
+	},
+	"14,63": {
+		"terrainType": "LAND"
+	},
+	"15,0": {
+		"terrainType": "LAND"
+	},
+	"15,1": {
+		"terrainType": "LAND"
+	},
+	"15,2": {
+		"terrainType": "LAND"
+	},
+	"15,3": {
+		"terrainType": "LAND"
+	},
+	"15,4": {
+		"terrainType": "LAND"
+	},
+	"15,5": {
+		"terrainType": "LAND"
+	},
+	"15,6": {
+		"terrainType": "LAND"
+	},
+	"15,7": {
+		"terrainType": "LAND"
+	},
+	"15,8": {
+		"terrainType": "LAND"
+	},
+	"15,9": {
+		"terrainType": "LAND"
+	},
+	"15,10": {
+		"terrainType": "LAND"
+	},
+	"15,11": {
+		"terrainType": "LAND"
+	},
+	"15,12": {
+		"terrainType": "LAND"
+	},
+	"15,13": {
+		"terrainType": "LAND"
+	},
+	"15,14": {
+		"terrainType": "LAND"
+	},
+	"15,15": {
+		"terrainType": "LAND"
+	},
+	"15,16": {
+		"terrainType": "LAND"
+	},
+	"15,17": {
+		"terrainType": "LAND"
+	},
+	"15,18": {
+		"terrainType": "LAND"
+	},
+	"15,19": {
+		"terrainType": "LAND"
+	},
+	"15,20": {
+		"terrainType": "LAND"
+	},
+	"15,21": {
+		"terrainType": "LAND"
+	},
+	"15,22": {
+		"terrainType": "LAND"
+	},
+	"15,23": {
+		"terrainType": "LAND"
+	},
+	"15,24": {
+		"terrainType": "LAND"
+	},
+	"15,25": {
+		"terrainType": "LAND"
+	},
+	"15,26": {
+		"terrainType": "LAND"
+	},
+	"15,27": {
+		"terrainType": "LAND"
+	},
+	"15,28": {
+		"terrainType": "LAND"
+	},
+	"15,29": {
+		"terrainType": "LAND"
+	},
+	"15,30": {
+		"terrainType": "LAND"
+	},
+	"15,31": {
+		"terrainType": "LAND"
+	},
+	"15,32": {
+		"terrainType": "LAND"
+	},
+	"15,33": {
+		"terrainType": "LAND"
+	},
+	"15,34": {
+		"terrainType": "LAND"
+	},
+	"15,35": {
+		"terrainType": "LAND"
+	},
+	"15,36": {
+		"terrainType": "LAND"
+	},
+	"15,37": {
+		"terrainType": "LAND"
+	},
+	"15,38": {
+		"terrainType": "LAND"
+	},
+	"15,39": {
+		"terrainType": "LAND"
+	},
+	"15,40": {
+		"terrainType": "LAND"
+	},
+	"15,41": {
+		"terrainType": "LAND"
+	},
+	"15,42": {
+		"terrainType": "LAND"
+	},
+	"15,43": {
+		"terrainType": "LAND"
+	},
+	"15,44": {
+		"terrainType": "LAND"
+	},
+	"15,45": {
+		"terrainType": "LAND"
+	},
+	"15,46": {
+		"terrainType": "LAND"
+	},
+	"15,47": {
+		"terrainType": "LAND"
+	},
+	"15,48": {
+		"terrainType": "LAND"
+	},
+	"15,49": {
+		"terrainType": "LAND"
+	},
+	"15,50": {
+		"terrainType": "LAND"
+	},
+	"15,51": {
+		"terrainType": "LAND"
+	},
+	"15,52": {
+		"terrainType": "LAND"
+	},
+	"15,53": {
+		"terrainType": "LAND"
+	},
+	"15,54": {
+		"terrainType": "LAND"
+	},
+	"15,55": {
+		"terrainType": "LAND"
+	},
+	"15,56": {
+		"terrainType": "LAND"
+	},
+	"15,57": {
+		"terrainType": "LAND"
+	},
+	"15,58": {
+		"terrainType": "LAND"
+	},
+	"15,59": {
+		"terrainType": "LAND"
+	},
+	"15,60": {
+		"terrainType": "LAND"
+	},
+	"15,61": {
+		"terrainType": "LAND"
+	},
+	"15,62": {
+		"terrainType": "LAND"
+	},
+	"15,63": {
+		"terrainType": "LAND"
+	},
+	"16,0": {
+		"terrainType": "LAND"
+	},
+	"16,1": {
+		"terrainType": "LAND"
+	},
+	"16,2": {
+		"terrainType": "LAND"
+	},
+	"16,3": {
+		"terrainType": "LAND"
+	},
+	"16,4": {
+		"terrainType": "LAND"
+	},
+	"16,5": {
+		"terrainType": "LAND"
+	},
+	"16,6": {
+		"terrainType": "LAND"
+	},
+	"16,7": {
+		"terrainType": "LAND"
+	},
+	"16,8": {
+		"terrainType": "LAND"
+	},
+	"16,9": {
+		"terrainType": "LAND"
+	},
+	"16,10": {
+		"terrainType": "LAND"
+	},
+	"16,11": {
+		"terrainType": "LAND"
+	},
+	"16,12": {
+		"terrainType": "LAND"
+	},
+	"16,13": {
+		"terrainType": "LAND"
+	},
+	"16,14": {
+		"terrainType": "LAND"
+	},
+	"16,15": {
+		"terrainType": "LAND"
+	},
+	"16,16": {
+		"terrainType": "LAND"
+	},
+	"16,17": {
+		"terrainType": "LAND"
+	},
+	"16,18": {
+		"terrainType": "LAND"
+	},
+	"16,19": {
+		"terrainType": "LAND"
+	},
+	"16,20": {
+		"terrainType": "LAND"
+	},
+	"16,21": {
+		"terrainType": "LAND"
+	},
+	"16,22": {
+		"terrainType": "LAND"
+	},
+	"16,23": {
+		"terrainType": "LAND"
+	},
+	"16,24": {
+		"terrainType": "LAND"
+	},
+	"16,25": {
+		"terrainType": "LAND"
+	},
+	"16,26": {
+		"terrainType": "LAND"
+	},
+	"16,27": {
+		"terrainType": "LAND"
+	},
+	"16,28": {
+		"terrainType": "LAND"
+	},
+	"16,29": {
+		"terrainType": "LAND"
+	},
+	"16,30": {
+		"terrainType": "LAND"
+	},
+	"16,31": {
+		"terrainType": "LAND"
+	},
+	"16,32": {
+		"terrainType": "LAND"
+	},
+	"16,33": {
+		"terrainType": "LAND"
+	},
+	"16,34": {
+		"terrainType": "LAND"
+	},
+	"16,35": {
+		"terrainType": "LAND"
+	},
+	"16,36": {
+		"terrainType": "LAND"
+	},
+	"16,37": {
+		"terrainType": "LAND"
+	},
+	"16,38": {
+		"terrainType": "LAND"
+	},
+	"16,39": {
+		"terrainType": "LAND"
+	},
+	"16,40": {
+		"terrainType": "LAND"
+	},
+	"16,41": {
+		"terrainType": "LAND"
+	},
+	"16,42": {
+		"terrainType": "LAND"
+	},
+	"16,43": {
+		"terrainType": "LAND"
+	},
+	"16,44": {
+		"terrainType": "LAND"
+	},
+	"16,45": {
+		"terrainType": "LAND"
+	},
+	"16,46": {
+		"terrainType": "LAND"
+	},
+	"16,47": {
+		"terrainType": "LAND"
+	},
+	"16,48": {
+		"terrainType": "LAND"
+	},
+	"16,49": {
+		"terrainType": "LAND"
+	},
+	"16,50": {
+		"terrainType": "LAND"
+	},
+	"16,51": {
+		"terrainType": "LAND"
+	},
+	"16,52": {
+		"terrainType": "LAND"
+	},
+	"16,53": {
+		"terrainType": "LAND"
+	},
+	"16,54": {
+		"terrainType": "LAND"
+	},
+	"16,55": {
+		"terrainType": "LAND"
+	},
+	"16,56": {
+		"terrainType": "LAND"
+	},
+	"16,57": {
+		"terrainType": "LAND"
+	},
+	"16,58": {
+		"terrainType": "LAND"
+	},
+	"16,59": {
+		"terrainType": "LAND"
+	},
+	"16,60": {
+		"terrainType": "LAND"
+	},
+	"16,61": {
+		"terrainType": "LAND"
+	},
+	"16,62": {
+		"terrainType": "LAND"
+	},
+	"16,63": {
+		"terrainType": "LAND"
+	},
+	"17,0": {
+		"terrainType": "LAND"
+	},
+	"17,1": {
+		"terrainType": "LAND"
+	},
+	"17,2": {
+		"terrainType": "LAND"
+	},
+	"17,3": {
+		"terrainType": "LAND"
+	},
+	"17,4": {
+		"terrainType": "LAND"
+	},
+	"17,5": {
+		"terrainType": "LAND"
+	},
+	"17,6": {
+		"terrainType": "LAND"
+	},
+	"17,7": {
+		"terrainType": "LAND"
+	},
+	"17,8": {
+		"terrainType": "LAND"
+	},
+	"17,9": {
+		"terrainType": "LAND"
+	},
+	"17,10": {
+		"terrainType": "LAND"
+	},
+	"17,11": {
+		"terrainType": "LAND"
+	},
+	"17,12": {
+		"terrainType": "LAND"
+	},
+	"17,13": {
+		"terrainType": "LAND"
+	},
+	"17,14": {
+		"terrainType": "LAND"
+	},
+	"17,15": {
+		"terrainType": "LAND"
+	},
+	"17,16": {
+		"terrainType": "LAND"
+	},
+	"17,17": {
+		"terrainType": "LAND"
+	},
+	"17,18": {
+		"terrainType": "LAND"
+	},
+	"17,19": {
+		"terrainType": "LAND"
+	},
+	"17,20": {
+		"terrainType": "LAND"
+	},
+	"17,21": {
+		"terrainType": "LAND"
+	},
+	"17,22": {
+		"terrainType": "LAND"
+	},
+	"17,23": {
+		"terrainType": "LAND"
+	},
+	"17,24": {
+		"terrainType": "LAND"
+	},
+	"17,25": {
+		"terrainType": "LAND"
+	},
+	"17,26": {
+		"terrainType": "LAND"
+	},
+	"17,27": {
+		"terrainType": "LAND"
+	},
+	"17,28": {
+		"terrainType": "LAND"
+	},
+	"17,29": {
+		"terrainType": "LAND"
+	},
+	"17,30": {
+		"terrainType": "LAND"
+	},
+	"17,31": {
+		"terrainType": "LAND"
+	},
+	"17,32": {
+		"terrainType": "LAND"
+	},
+	"17,33": {
+		"terrainType": "LAND"
+	},
+	"17,34": {
+		"terrainType": "LAND"
+	},
+	"17,35": {
+		"terrainType": "LAND"
+	},
+	"17,36": {
+		"terrainType": "LAND"
+	},
+	"17,37": {
+		"terrainType": "LAND"
+	},
+	"17,38": {
+		"terrainType": "LAND"
+	},
+	"17,39": {
+		"terrainType": "LAND"
+	},
+	"17,40": {
+		"terrainType": "LAND"
+	},
+	"17,41": {
+		"terrainType": "LAND"
+	},
+	"17,42": {
+		"terrainType": "LAND"
+	},
+	"17,43": {
+		"terrainType": "LAND"
+	},
+	"17,44": {
+		"terrainType": "LAND"
+	},
+	"17,45": {
+		"terrainType": "LAND"
+	},
+	"17,46": {
+		"terrainType": "LAND"
+	},
+	"17,47": {
+		"terrainType": "LAND"
+	},
+	"17,48": {
+		"terrainType": "LAND"
+	},
+	"17,49": {
+		"terrainType": "LAND"
+	},
+	"17,50": {
+		"terrainType": "LAND"
+	},
+	"17,51": {
+		"terrainType": "LAND"
+	},
+	"17,52": {
+		"terrainType": "LAND"
+	},
+	"17,53": {
+		"terrainType": "LAND"
+	},
+	"17,54": {
+		"terrainType": "LAND"
+	},
+	"17,55": {
+		"terrainType": "LAND"
+	},
+	"17,56": {
+		"terrainType": "LAND"
+	},
+	"17,57": {
+		"terrainType": "LAND"
+	},
+	"17,58": {
+		"terrainType": "LAND"
+	},
+	"17,59": {
+		"terrainType": "LAND"
+	},
+	"17,60": {
+		"terrainType": "LAND"
+	},
+	"17,61": {
+		"terrainType": "LAND"
+	},
+	"17,62": {
+		"terrainType": "LAND"
+	},
+	"17,63": {
+		"terrainType": "LAND"
+	},
+	"18,0": {
+		"terrainType": "LAND"
+	},
+	"18,1": {
+		"terrainType": "LAND"
+	},
+	"18,2": {
+		"terrainType": "LAND"
+	},
+	"18,3": {
+		"terrainType": "LAND"
+	},
+	"18,4": {
+		"terrainType": "LAND"
+	},
+	"18,5": {
+		"terrainType": "LAND"
+	},
+	"18,6": {
+		"terrainType": "LAND"
+	},
+	"18,7": {
+		"terrainType": "LAND"
+	},
+	"18,8": {
+		"terrainType": "LAND"
+	},
+	"18,9": {
+		"terrainType": "LAND"
+	},
+	"18,10": {
+		"terrainType": "LAND"
+	},
+	"18,11": {
+		"terrainType": "LAND"
+	},
+	"18,12": {
+		"terrainType": "LAND"
+	},
+	"18,13": {
+		"terrainType": "LAND"
+	},
+	"18,14": {
+		"terrainType": "LAND"
+	},
+	"18,15": {
+		"terrainType": "LAND"
+	},
+	"18,16": {
+		"terrainType": "LAND"
+	},
+	"18,17": {
+		"terrainType": "LAND"
+	},
+	"18,18": {
+		"terrainType": "LAND"
+	},
+	"18,19": {
+		"terrainType": "LAND"
+	},
+	"18,20": {
+		"terrainType": "LAND"
+	},
+	"18,21": {
+		"terrainType": "LAND"
+	},
+	"18,22": {
+		"terrainType": "LAND"
+	},
+	"18,23": {
+		"terrainType": "LAND"
+	},
+	"18,24": {
+		"terrainType": "LAND"
+	},
+	"18,25": {
+		"terrainType": "LAND"
+	},
+	"18,26": {
+		"terrainType": "LAND"
+	},
+	"18,27": {
+		"terrainType": "LAND"
+	},
+	"18,28": {
+		"terrainType": "LAND"
+	},
+	"18,29": {
+		"terrainType": "LAND"
+	},
+	"18,30": {
+		"terrainType": "LAND"
+	},
+	"18,31": {
+		"terrainType": "LAND"
+	},
+	"18,32": {
+		"terrainType": "LAND"
+	},
+	"18,33": {
+		"terrainType": "LAND"
+	},
+	"18,34": {
+		"terrainType": "LAND"
+	},
+	"18,35": {
+		"terrainType": "LAND"
+	},
+	"18,36": {
+		"terrainType": "LAND"
+	},
+	"18,37": {
+		"terrainType": "LAND"
+	},
+	"18,38": {
+		"terrainType": "LAND"
+	},
+	"18,39": {
+		"terrainType": "LAND"
+	},
+	"18,40": {
+		"terrainType": "LAND"
+	},
+	"18,41": {
+		"terrainType": "LAND"
+	},
+	"18,42": {
+		"terrainType": "LAND"
+	},
+	"18,43": {
+		"terrainType": "LAND"
+	},
+	"18,44": {
+		"terrainType": "LAND"
+	},
+	"18,45": {
+		"terrainType": "LAND"
+	},
+	"18,46": {
+		"terrainType": "LAND"
+	},
+	"18,47": {
+		"terrainType": "LAND"
+	},
+	"18,48": {
+		"terrainType": "LAND"
+	},
+	"18,49": {
+		"terrainType": "LAND"
+	},
+	"18,50": {
+		"terrainType": "LAND"
+	},
+	"18,51": {
+		"terrainType": "LAND"
+	},
+	"18,52": {
+		"terrainType": "LAND"
+	},
+	"18,53": {
+		"terrainType": "LAND"
+	},
+	"18,54": {
+		"terrainType": "LAND"
+	},
+	"18,55": {
+		"terrainType": "LAND"
+	},
+	"18,56": {
+		"terrainType": "LAND"
+	},
+	"18,57": {
+		"terrainType": "LAND"
+	},
+	"18,58": {
+		"terrainType": "LAND"
+	},
+	"18,59": {
+		"terrainType": "LAND"
+	},
+	"18,60": {
+		"terrainType": "LAND"
+	},
+	"18,61": {
+		"terrainType": "LAND"
+	},
+	"18,62": {
+		"terrainType": "LAND"
+	},
+	"18,63": {
+		"terrainType": "LAND"
+	},
+	"19,0": {
+		"terrainType": "LAND"
+	},
+	"19,1": {
+		"terrainType": "LAND"
+	},
+	"19,2": {
+		"terrainType": "LAND"
+	},
+	"19,3": {
+		"terrainType": "LAND"
+	},
+	"19,4": {
+		"terrainType": "LAND"
+	},
+	"19,5": {
+		"terrainType": "LAND"
+	},
+	"19,6": {
+		"terrainType": "LAND"
+	},
+	"19,7": {
+		"terrainType": "LAND"
+	},
+	"19,8": {
+		"terrainType": "LAND"
+	},
+	"19,9": {
+		"terrainType": "LAND"
+	},
+	"19,10": {
+		"terrainType": "LAND"
+	},
+	"19,11": {
+		"terrainType": "LAND"
+	},
+	"19,12": {
+		"terrainType": "LAND"
+	},
+	"19,13": {
+		"terrainType": "LAND"
+	},
+	"19,14": {
+		"terrainType": "LAND"
+	},
+	"19,15": {
+		"terrainType": "LAND"
+	},
+	"19,16": {
+		"terrainType": "LAND"
+	},
+	"19,17": {
+		"terrainType": "LAND"
+	},
+	"19,18": {
+		"terrainType": "LAND"
+	},
+	"19,19": {
+		"terrainType": "LAND"
+	},
+	"19,20": {
+		"terrainType": "LAND"
+	},
+	"19,21": {
+		"terrainType": "LAND"
+	},
+	"19,22": {
+		"terrainType": "LAND"
+	},
+	"19,23": {
+		"terrainType": "LAND"
+	},
+	"19,24": {
+		"terrainType": "LAND"
+	},
+	"19,25": {
+		"terrainType": "LAND"
+	},
+	"19,26": {
+		"terrainType": "LAND"
+	},
+	"19,27": {
+		"terrainType": "LAND"
+	},
+	"19,28": {
+		"terrainType": "LAND"
+	},
+	"19,29": {
+		"terrainType": "LAND"
+	},
+	"19,30": {
+		"terrainType": "LAND"
+	},
+	"19,31": {
+		"terrainType": "LAND"
+	},
+	"19,32": {
+		"terrainType": "LAND"
+	},
+	"19,33": {
+		"terrainType": "LAND"
+	},
+	"19,34": {
+		"terrainType": "LAND"
+	},
+	"19,35": {
+		"terrainType": "LAND"
+	},
+	"19,36": {
+		"terrainType": "LAND"
+	},
+	"19,37": {
+		"terrainType": "LAND"
+	},
+	"19,38": {
+		"terrainType": "LAND"
+	},
+	"19,39": {
+		"terrainType": "LAND"
+	},
+	"19,40": {
+		"terrainType": "LAND"
+	},
+	"19,41": {
+		"terrainType": "LAND"
+	},
+	"19,42": {
+		"terrainType": "LAND"
+	},
+	"19,43": {
+		"terrainType": "LAND"
+	},
+	"19,44": {
+		"terrainType": "LAND"
+	},
+	"19,45": {
+		"terrainType": "LAND"
+	},
+	"19,46": {
+		"terrainType": "LAND"
+	},
+	"19,47": {
+		"terrainType": "LAND"
+	},
+	"19,48": {
+		"terrainType": "LAND"
+	},
+	"19,49": {
+		"terrainType": "LAND"
+	},
+	"19,50": {
+		"terrainType": "LAND"
+	},
+	"19,51": {
+		"terrainType": "LAND"
+	},
+	"19,52": {
+		"terrainType": "LAND"
+	},
+	"19,53": {
+		"terrainType": "LAND"
+	},
+	"19,54": {
+		"terrainType": "LAND"
+	},
+	"19,55": {
+		"terrainType": "LAND"
+	},
+	"19,56": {
+		"terrainType": "LAND"
+	},
+	"19,57": {
+		"terrainType": "LAND"
+	},
+	"19,58": {
+		"terrainType": "LAND"
+	},
+	"19,59": {
+		"terrainType": "LAND"
+	},
+	"19,60": {
+		"terrainType": "LAND"
+	},
+	"19,61": {
+		"terrainType": "LAND"
+	},
+	"19,62": {
+		"terrainType": "LAND"
+	},
+	"19,63": {
+		"terrainType": "LAND"
+	},
+	"20,0": {
+		"terrainType": "LAND"
+	},
+	"20,1": {
+		"terrainType": "LAND"
+	},
+	"20,2": {
+		"terrainType": "LAND"
+	},
+	"20,3": {
+		"terrainType": "LAND"
+	},
+	"20,4": {
+		"terrainType": "LAND"
+	},
+	"20,5": {
+		"terrainType": "LAND"
+	},
+	"20,6": {
+		"terrainType": "LAND"
+	},
+	"20,7": {
+		"terrainType": "LAND"
+	},
+	"20,8": {
+		"terrainType": "LAND"
+	},
+	"20,9": {
+		"terrainType": "LAND"
+	},
+	"20,10": {
+		"terrainType": "LAND"
+	},
+	"20,11": {
+		"terrainType": "LAND"
+	},
+	"20,12": {
+		"terrainType": "LAND"
+	},
+	"20,13": {
+		"terrainType": "LAND"
+	},
+	"20,14": {
+		"terrainType": "LAND"
+	},
+	"20,15": {
+		"terrainType": "LAND"
+	},
+	"20,16": {
+		"terrainType": "LAND"
+	},
+	"20,17": {
+		"terrainType": "LAND"
+	},
+	"20,18": {
+		"terrainType": "LAND"
+	},
+	"20,19": {
+		"terrainType": "LAND"
+	},
+	"20,20": {
+		"terrainType": "LAND"
+	},
+	"20,21": {
+		"terrainType": "LAND"
+	},
+	"20,22": {
+		"terrainType": "LAND"
+	},
+	"20,23": {
+		"terrainType": "LAND"
+	},
+	"20,24": {
+		"terrainType": "LAND"
+	},
+	"20,25": {
+		"terrainType": "LAND"
+	},
+	"20,26": {
+		"terrainType": "LAND"
+	},
+	"20,27": {
+		"terrainType": "LAND"
+	},
+	"20,28": {
+		"terrainType": "LAND"
+	},
+	"20,29": {
+		"terrainType": "LAND"
+	},
+	"20,30": {
+		"terrainType": "LAND"
+	},
+	"20,31": {
+		"terrainType": "LAND"
+	},
+	"20,32": {
+		"terrainType": "LAND"
+	},
+	"20,33": {
+		"terrainType": "LAND"
+	},
+	"20,34": {
+		"terrainType": "LAND"
+	},
+	"20,35": {
+		"terrainType": "LAND"
+	},
+	"20,36": {
+		"terrainType": "LAND"
+	},
+	"20,37": {
+		"terrainType": "LAND"
+	},
+	"20,38": {
+		"terrainType": "LAND"
+	},
+	"20,39": {
+		"terrainType": "LAND"
+	},
+	"20,40": {
+		"terrainType": "LAND"
+	},
+	"20,41": {
+		"terrainType": "LAND"
+	},
+	"20,42": {
+		"terrainType": "LAND"
+	},
+	"20,43": {
+		"terrainType": "LAND"
+	},
+	"20,44": {
+		"terrainType": "LAND"
+	},
+	"20,45": {
+		"terrainType": "LAND"
+	},
+	"20,46": {
+		"terrainType": "LAND"
+	},
+	"20,47": {
+		"terrainType": "LAND"
+	},
+	"20,48": {
+		"terrainType": "LAND"
+	},
+	"20,49": {
+		"terrainType": "LAND"
+	},
+	"20,50": {
+		"terrainType": "LAND"
+	},
+	"20,51": {
+		"terrainType": "LAND"
+	},
+	"20,52": {
+		"terrainType": "LAND"
+	},
+	"20,53": {
+		"terrainType": "LAND"
+	},
+	"20,54": {
+		"terrainType": "LAND"
+	},
+	"20,55": {
+		"terrainType": "LAND"
+	},
+	"20,56": {
+		"terrainType": "LAND"
+	},
+	"20,57": {
+		"terrainType": "LAND"
+	},
+	"20,58": {
+		"terrainType": "LAND"
+	},
+	"20,59": {
+		"terrainType": "LAND"
+	},
+	"20,60": {
+		"terrainType": "LAND"
+	},
+	"20,61": {
+		"terrainType": "LAND"
+	},
+	"20,62": {
+		"terrainType": "LAND"
+	},
+	"20,63": {
+		"terrainType": "LAND"
+	},
+	"21,0": {
+		"terrainType": "LAND"
+	},
+	"21,1": {
+		"terrainType": "LAND"
+	},
+	"21,2": {
+		"terrainType": "LAND"
+	},
+	"21,3": {
+		"terrainType": "LAND"
+	},
+	"21,4": {
+		"terrainType": "LAND"
+	},
+	"21,5": {
+		"terrainType": "LAND"
+	},
+	"21,6": {
+		"terrainType": "LAND"
+	},
+	"21,7": {
+		"terrainType": "LAND"
+	},
+	"21,8": {
+		"terrainType": "LAND"
+	},
+	"21,9": {
+		"terrainType": "LAND"
+	},
+	"21,10": {
+		"terrainType": "LAND"
+	},
+	"21,11": {
+		"terrainType": "LAND"
+	},
+	"21,12": {
+		"terrainType": "LAND"
+	},
+	"21,13": {
+		"terrainType": "LAND"
+	},
+	"21,14": {
+		"terrainType": "LAND"
+	},
+	"21,15": {
+		"terrainType": "LAND"
+	},
+	"21,16": {
+		"terrainType": "LAND"
+	},
+	"21,17": {
+		"terrainType": "LAND"
+	},
+	"21,18": {
+		"terrainType": "LAND"
+	},
+	"21,19": {
+		"terrainType": "LAND"
+	},
+	"21,20": {
+		"terrainType": "LAND"
+	},
+	"21,21": {
+		"terrainType": "LAND"
+	},
+	"21,22": {
+		"terrainType": "LAND"
+	},
+	"21,23": {
+		"terrainType": "LAND"
+	},
+	"21,24": {
+		"terrainType": "LAND"
+	},
+	"21,25": {
+		"terrainType": "LAND"
+	},
+	"21,26": {
+		"terrainType": "LAND"
+	},
+	"21,27": {
+		"terrainType": "LAND"
+	},
+	"21,28": {
+		"terrainType": "LAND"
+	},
+	"21,29": {
+		"terrainType": "LAND"
+	},
+	"21,30": {
+		"terrainType": "LAND"
+	},
+	"21,31": {
+		"terrainType": "LAND"
+	},
+	"21,32": {
+		"terrainType": "LAND"
+	},
+	"21,33": {
+		"terrainType": "LAND"
+	},
+	"21,34": {
+		"terrainType": "LAND"
+	},
+	"21,35": {
+		"terrainType": "LAND"
+	},
+	"21,36": {
+		"terrainType": "LAND"
+	},
+	"21,37": {
+		"terrainType": "LAND"
+	},
+	"21,38": {
+		"terrainType": "LAND"
+	},
+	"21,39": {
+		"terrainType": "LAND"
+	},
+	"21,40": {
+		"terrainType": "LAND"
+	},
+	"21,41": {
+		"terrainType": "LAND"
+	},
+	"21,42": {
+		"terrainType": "LAND"
+	},
+	"21,43": {
+		"terrainType": "LAND"
+	},
+	"21,44": {
+		"terrainType": "LAND"
+	},
+	"21,45": {
+		"terrainType": "LAND"
+	},
+	"21,46": {
+		"terrainType": "LAND"
+	},
+	"21,47": {
+		"terrainType": "LAND"
+	},
+	"21,48": {
+		"terrainType": "LAND"
+	},
+	"21,49": {
+		"terrainType": "LAND"
+	},
+	"21,50": {
+		"terrainType": "LAND"
+	},
+	"21,51": {
+		"terrainType": "LAND"
+	},
+	"21,52": {
+		"terrainType": "LAND"
+	},
+	"21,53": {
+		"terrainType": "LAND"
+	},
+	"21,54": {
+		"terrainType": "LAND"
+	},
+	"21,55": {
+		"terrainType": "LAND"
+	},
+	"21,56": {
+		"terrainType": "LAND"
+	},
+	"21,57": {
+		"terrainType": "LAND"
+	},
+	"21,58": {
+		"terrainType": "LAND"
+	},
+	"21,59": {
+		"terrainType": "LAND"
+	},
+	"21,60": {
+		"terrainType": "LAND"
+	},
+	"21,61": {
+		"terrainType": "LAND"
+	},
+	"21,62": {
+		"terrainType": "LAND"
+	},
+	"21,63": {
+		"terrainType": "LAND"
+	},
+	"22,0": {
+		"terrainType": "LAND"
+	},
+	"22,1": {
+		"terrainType": "LAND"
+	},
+	"22,2": {
+		"terrainType": "LAND"
+	},
+	"22,3": {
+		"terrainType": "LAND"
+	},
+	"22,4": {
+		"terrainType": "LAND"
+	},
+	"22,5": {
+		"terrainType": "LAND"
+	},
+	"22,6": {
+		"terrainType": "LAND"
+	},
+	"22,7": {
+		"terrainType": "LAND"
+	},
+	"22,8": {
+		"terrainType": "LAND"
+	},
+	"22,9": {
+		"terrainType": "LAND"
+	},
+	"22,10": {
+		"terrainType": "LAND"
+	},
+	"22,11": {
+		"terrainType": "LAND"
+	},
+	"22,12": {
+		"terrainType": "LAND"
+	},
+	"22,13": {
+		"terrainType": "LAND"
+	},
+	"22,14": {
+		"terrainType": "LAND"
+	},
+	"22,15": {
+		"terrainType": "LAND"
+	},
+	"22,16": {
+		"terrainType": "LAND"
+	},
+	"22,17": {
+		"terrainType": "LAND"
+	},
+	"22,18": {
+		"terrainType": "LAND"
+	},
+	"22,19": {
+		"terrainType": "LAND"
+	},
+	"22,20": {
+		"terrainType": "LAND"
+	},
+	"22,21": {
+		"terrainType": "LAND"
+	},
+	"22,22": {
+		"terrainType": "LAND"
+	},
+	"22,23": {
+		"terrainType": "LAND"
+	},
+	"22,24": {
+		"terrainType": "LAND"
+	},
+	"22,25": {
+		"terrainType": "LAND"
+	},
+	"22,26": {
+		"terrainType": "LAND"
+	},
+	"22,27": {
+		"terrainType": "LAND"
+	},
+	"22,28": {
+		"terrainType": "LAND"
+	},
+	"22,29": {
+		"terrainType": "LAND"
+	},
+	"22,30": {
+		"terrainType": "LAND"
+	},
+	"22,31": {
+		"terrainType": "LAND"
+	},
+	"22,32": {
+		"terrainType": "LAND"
+	},
+	"22,33": {
+		"terrainType": "LAND"
+	},
+	"22,34": {
+		"terrainType": "LAND"
+	},
+	"22,35": {
+		"terrainType": "LAND"
+	},
+	"22,36": {
+		"terrainType": "LAND"
+	},
+	"22,37": {
+		"terrainType": "LAND"
+	},
+	"22,38": {
+		"terrainType": "LAND"
+	},
+	"22,39": {
+		"terrainType": "LAND"
+	},
+	"22,40": {
+		"terrainType": "LAND"
+	},
+	"22,41": {
+		"terrainType": "LAND"
+	},
+	"22,42": {
+		"terrainType": "LAND"
+	},
+	"22,43": {
+		"terrainType": "LAND"
+	},
+	"22,44": {
+		"terrainType": "LAND"
+	},
+	"22,45": {
+		"terrainType": "LAND"
+	},
+	"22,46": {
+		"terrainType": "LAND"
+	},
+	"22,47": {
+		"terrainType": "LAND"
+	},
+	"22,48": {
+		"terrainType": "LAND"
+	},
+	"22,49": {
+		"terrainType": "LAND"
+	},
+	"22,50": {
+		"terrainType": "LAND"
+	},
+	"22,51": {
+		"terrainType": "LAND"
+	},
+	"22,52": {
+		"terrainType": "LAND"
+	},
+	"22,53": {
+		"terrainType": "LAND"
+	},
+	"22,54": {
+		"terrainType": "LAND"
+	},
+	"22,55": {
+		"terrainType": "LAND"
+	},
+	"22,56": {
+		"terrainType": "LAND"
+	},
+	"22,57": {
+		"terrainType": "LAND"
+	},
+	"22,58": {
+		"terrainType": "LAND"
+	},
+	"22,59": {
+		"terrainType": "LAND"
+	},
+	"22,60": {
+		"terrainType": "LAND"
+	},
+	"22,61": {
+		"terrainType": "LAND"
+	},
+	"22,62": {
+		"terrainType": "LAND"
+	},
+	"22,63": {
+		"terrainType": "LAND"
+	},
+	"23,0": {
+		"terrainType": "LAND"
+	},
+	"23,1": {
+		"terrainType": "LAND"
+	},
+	"23,2": {
+		"terrainType": "LAND"
+	},
+	"23,3": {
+		"terrainType": "LAND"
+	},
+	"23,4": {
+		"terrainType": "LAND"
+	},
+	"23,5": {
+		"terrainType": "LAND"
+	},
+	"23,6": {
+		"terrainType": "LAND"
+	},
+	"23,7": {
+		"terrainType": "LAND"
+	},
+	"23,8": {
+		"terrainType": "LAND"
+	},
+	"23,9": {
+		"terrainType": "LAND"
+	},
+	"23,10": {
+		"terrainType": "LAND"
+	},
+	"23,11": {
+		"terrainType": "LAND"
+	},
+	"23,12": {
+		"terrainType": "LAND"
+	},
+	"23,13": {
+		"terrainType": "LAND"
+	},
+	"23,14": {
+		"terrainType": "LAND"
+	},
+	"23,15": {
+		"terrainType": "LAND"
+	},
+	"23,16": {
+		"terrainType": "LAND"
+	},
+	"23,17": {
+		"terrainType": "LAND"
+	},
+	"23,18": {
+		"terrainType": "LAND"
+	},
+	"23,19": {
+		"terrainType": "LAND"
+	},
+	"23,20": {
+		"terrainType": "LAND"
+	},
+	"23,21": {
+		"terrainType": "LAND"
+	},
+	"23,22": {
+		"terrainType": "LAND"
+	},
+	"23,23": {
+		"terrainType": "LAND"
+	},
+	"23,24": {
+		"terrainType": "LAND"
+	},
+	"23,25": {
+		"terrainType": "LAND"
+	},
+	"23,26": {
+		"terrainType": "LAND"
+	},
+	"23,27": {
+		"terrainType": "LAND"
+	},
+	"23,28": {
+		"terrainType": "LAND"
+	},
+	"23,29": {
+		"terrainType": "LAND"
+	},
+	"23,30": {
+		"terrainType": "LAND"
+	},
+	"23,31": {
+		"terrainType": "LAND"
+	},
+	"23,32": {
+		"terrainType": "LAND"
+	},
+	"23,33": {
+		"terrainType": "LAND"
+	},
+	"23,34": {
+		"terrainType": "LAND"
+	},
+	"23,35": {
+		"terrainType": "LAND"
+	},
+	"23,36": {
+		"terrainType": "LAND"
+	},
+	"23,37": {
+		"terrainType": "LAND"
+	},
+	"23,38": {
+		"terrainType": "LAND"
+	},
+	"23,39": {
+		"terrainType": "LAND"
+	},
+	"23,40": {
+		"terrainType": "LAND"
+	},
+	"23,41": {
+		"terrainType": "LAND"
+	},
+	"23,42": {
+		"terrainType": "LAND"
+	},
+	"23,43": {
+		"terrainType": "LAND"
+	},
+	"23,44": {
+		"terrainType": "LAND"
+	},
+	"23,45": {
+		"terrainType": "LAND"
+	},
+	"23,46": {
+		"terrainType": "LAND"
+	},
+	"23,47": {
+		"terrainType": "LAND"
+	},
+	"23,48": {
+		"terrainType": "LAND"
+	},
+	"23,49": {
+		"terrainType": "LAND"
+	},
+	"23,50": {
+		"terrainType": "LAND"
+	},
+	"23,51": {
+		"terrainType": "LAND"
+	},
+	"23,52": {
+		"terrainType": "LAND"
+	},
+	"23,53": {
+		"terrainType": "LAND"
+	},
+	"23,54": {
+		"terrainType": "LAND"
+	},
+	"23,55": {
+		"terrainType": "LAND"
+	},
+	"23,56": {
+		"terrainType": "LAND"
+	},
+	"23,57": {
+		"terrainType": "LAND"
+	},
+	"23,58": {
+		"terrainType": "LAND"
+	},
+	"23,59": {
+		"terrainType": "LAND"
+	},
+	"23,60": {
+		"terrainType": "LAND"
+	},
+	"23,61": {
+		"terrainType": "LAND"
+	},
+	"23,62": {
+		"terrainType": "LAND"
+	},
+	"23,63": {
+		"terrainType": "LAND"
+	},
+	"24,0": {
+		"terrainType": "LAND"
+	},
+	"24,1": {
+		"terrainType": "LAND"
+	},
+	"24,2": {
+		"terrainType": "LAND"
+	},
+	"24,3": {
+		"terrainType": "LAND"
+	},
+	"24,4": {
+		"terrainType": "LAND"
+	},
+	"24,5": {
+		"terrainType": "LAND"
+	},
+	"24,6": {
+		"terrainType": "LAND"
+	},
+	"24,7": {
+		"terrainType": "LAND"
+	},
+	"24,8": {
+		"terrainType": "LAND"
+	},
+	"24,9": {
+		"terrainType": "LAND"
+	},
+	"24,10": {
+		"terrainType": "LAND"
+	},
+	"24,11": {
+		"terrainType": "LAND"
+	},
+	"24,12": {
+		"terrainType": "LAND"
+	},
+	"24,13": {
+		"terrainType": "LAND"
+	},
+	"24,14": {
+		"terrainType": "LAND"
+	},
+	"24,15": {
+		"terrainType": "LAND"
+	},
+	"24,16": {
+		"terrainType": "LAND"
+	},
+	"24,17": {
+		"terrainType": "LAND"
+	},
+	"24,18": {
+		"terrainType": "LAND"
+	},
+	"24,19": {
+		"terrainType": "LAND"
+	},
+	"24,20": {
+		"terrainType": "LAND"
+	},
+	"24,21": {
+		"terrainType": "LAND"
+	},
+	"24,22": {
+		"terrainType": "LAND"
+	},
+	"24,23": {
+		"terrainType": "LAND"
+	},
+	"24,24": {
+		"terrainType": "LAND"
+	},
+	"24,25": {
+		"terrainType": "LAND"
+	},
+	"24,26": {
+		"terrainType": "LAND"
+	},
+	"24,27": {
+		"terrainType": "LAND"
+	},
+	"24,28": {
+		"terrainType": "LAND"
+	},
+	"24,29": {
+		"terrainType": "LAND"
+	},
+	"24,30": {
+		"terrainType": "LAND"
+	},
+	"24,31": {
+		"terrainType": "LAND"
+	},
+	"24,32": {
+		"terrainType": "LAND"
+	},
+	"24,33": {
+		"terrainType": "LAND"
+	},
+	"24,34": {
+		"terrainType": "LAND"
+	},
+	"24,35": {
+		"terrainType": "LAND"
+	},
+	"24,36": {
+		"terrainType": "LAND"
+	},
+	"24,37": {
+		"terrainType": "LAND"
+	},
+	"24,38": {
+		"terrainType": "LAND"
+	},
+	"24,39": {
+		"terrainType": "LAND"
+	},
+	"24,40": {
+		"terrainType": "LAND"
+	},
+	"24,41": {
+		"terrainType": "LAND"
+	},
+	"24,42": {
+		"terrainType": "LAND"
+	},
+	"24,43": {
+		"terrainType": "LAND"
+	},
+	"24,44": {
+		"terrainType": "LAND"
+	},
+	"24,45": {
+		"terrainType": "LAND"
+	},
+	"24,46": {
+		"terrainType": "LAND"
+	},
+	"24,47": {
+		"terrainType": "LAND"
+	},
+	"24,48": {
+		"terrainType": "LAND"
+	},
+	"24,49": {
+		"terrainType": "LAND"
+	},
+	"24,50": {
+		"terrainType": "LAND"
+	},
+	"24,51": {
+		"terrainType": "LAND"
+	},
+	"24,52": {
+		"terrainType": "LAND"
+	},
+	"24,53": {
+		"terrainType": "LAND"
+	},
+	"24,54": {
+		"terrainType": "LAND"
+	},
+	"24,55": {
+		"terrainType": "LAND"
+	},
+	"24,56": {
+		"terrainType": "LAND"
+	},
+	"24,57": {
+		"terrainType": "LAND"
+	},
+	"24,58": {
+		"terrainType": "LAND"
+	},
+	"24,59": {
+		"terrainType": "LAND"
+	},
+	"24,60": {
+		"terrainType": "LAND"
+	},
+	"24,61": {
+		"terrainType": "LAND"
+	},
+	"24,62": {
+		"terrainType": "LAND"
+	},
+	"24,63": {
+		"terrainType": "LAND"
+	},
+	"25,0": {
+		"terrainType": "LAND"
+	},
+	"25,1": {
+		"terrainType": "LAND"
+	},
+	"25,2": {
+		"terrainType": "LAND"
+	},
+	"25,3": {
+		"terrainType": "LAND"
+	},
+	"25,4": {
+		"terrainType": "LAND"
+	},
+	"25,5": {
+		"terrainType": "LAND"
+	},
+	"25,6": {
+		"terrainType": "LAND"
+	},
+	"25,7": {
+		"terrainType": "LAND"
+	},
+	"25,8": {
+		"terrainType": "LAND"
+	},
+	"25,9": {
+		"terrainType": "LAND"
+	},
+	"25,10": {
+		"terrainType": "LAND"
+	},
+	"25,11": {
+		"terrainType": "LAND"
+	},
+	"25,12": {
+		"terrainType": "LAND"
+	},
+	"25,13": {
+		"terrainType": "LAND"
+	},
+	"25,14": {
+		"terrainType": "LAND"
+	},
+	"25,15": {
+		"terrainType": "LAND"
+	},
+	"25,16": {
+		"terrainType": "LAND"
+	},
+	"25,17": {
+		"terrainType": "LAND"
+	},
+	"25,18": {
+		"terrainType": "LAND"
+	},
+	"25,19": {
+		"terrainType": "LAND"
+	},
+	"25,20": {
+		"terrainType": "LAND"
+	},
+	"25,21": {
+		"terrainType": "LAND"
+	},
+	"25,22": {
+		"terrainType": "LAND"
+	},
+	"25,23": {
+		"terrainType": "LAND"
+	},
+	"25,24": {
+		"terrainType": "LAND"
+	},
+	"25,25": {
+		"terrainType": "LAND"
+	},
+	"25,26": {
+		"terrainType": "LAND"
+	},
+	"25,27": {
+		"terrainType": "LAND"
+	},
+	"25,28": {
+		"terrainType": "LAND"
+	},
+	"25,29": {
+		"terrainType": "LAND"
+	},
+	"25,30": {
+		"terrainType": "LAND"
+	},
+	"25,31": {
+		"terrainType": "LAND"
+	},
+	"25,32": {
+		"terrainType": "LAND"
+	},
+	"25,33": {
+		"terrainType": "LAND"
+	},
+	"25,34": {
+		"terrainType": "LAND"
+	},
+	"25,35": {
+		"terrainType": "LAND"
+	},
+	"25,36": {
+		"terrainType": "LAND"
+	},
+	"25,37": {
+		"terrainType": "LAND"
+	},
+	"25,38": {
+		"terrainType": "LAND"
+	},
+	"25,39": {
+		"terrainType": "LAND"
+	},
+	"25,40": {
+		"terrainType": "LAND"
+	},
+	"25,41": {
+		"terrainType": "LAND"
+	},
+	"25,42": {
+		"terrainType": "LAND"
+	},
+	"25,43": {
+		"terrainType": "LAND"
+	},
+	"25,44": {
+		"terrainType": "LAND"
+	},
+	"25,45": {
+		"terrainType": "LAND"
+	},
+	"25,46": {
+		"terrainType": "LAND"
+	},
+	"25,47": {
+		"terrainType": "LAND"
+	},
+	"25,48": {
+		"terrainType": "LAND"
+	},
+	"25,49": {
+		"terrainType": "LAND"
+	},
+	"25,50": {
+		"terrainType": "LAND"
+	},
+	"25,51": {
+		"terrainType": "LAND"
+	},
+	"25,52": {
+		"terrainType": "LAND"
+	},
+	"25,53": {
+		"terrainType": "LAND"
+	},
+	"25,54": {
+		"terrainType": "LAND"
+	},
+	"25,55": {
+		"terrainType": "LAND"
+	},
+	"25,56": {
+		"terrainType": "LAND"
+	},
+	"25,57": {
+		"terrainType": "LAND"
+	},
+	"25,58": {
+		"terrainType": "LAND"
+	},
+	"25,59": {
+		"terrainType": "LAND"
+	},
+	"25,60": {
+		"terrainType": "LAND"
+	},
+	"25,61": {
+		"terrainType": "LAND"
+	},
+	"25,62": {
+		"terrainType": "LAND"
+	},
+	"25,63": {
+		"terrainType": "LAND"
+	},
+	"26,0": {
+		"terrainType": "LAND"
+	},
+	"26,1": {
+		"terrainType": "LAND"
+	},
+	"26,2": {
+		"terrainType": "LAND"
+	},
+	"26,3": {
+		"terrainType": "LAND"
+	},
+	"26,4": {
+		"terrainType": "LAND"
+	},
+	"26,5": {
+		"terrainType": "LAND"
+	},
+	"26,6": {
+		"terrainType": "LAND"
+	},
+	"26,7": {
+		"terrainType": "LAND"
+	},
+	"26,8": {
+		"terrainType": "LAND"
+	},
+	"26,9": {
+		"terrainType": "LAND"
+	},
+	"26,10": {
+		"terrainType": "LAND"
+	},
+	"26,11": {
+		"terrainType": "LAND"
+	},
+	"26,12": {
+		"terrainType": "LAND"
+	},
+	"26,13": {
+		"terrainType": "LAND"
+	},
+	"26,14": {
+		"terrainType": "LAND"
+	},
+	"26,15": {
+		"terrainType": "LAND"
+	},
+	"26,16": {
+		"terrainType": "LAND"
+	},
+	"26,17": {
+		"terrainType": "LAND"
+	},
+	"26,18": {
+		"terrainType": "LAND"
+	},
+	"26,19": {
+		"terrainType": "LAND"
+	},
+	"26,20": {
+		"terrainType": "LAND"
+	},
+	"26,21": {
+		"terrainType": "LAND"
+	},
+	"26,22": {
+		"terrainType": "LAND"
+	},
+	"26,23": {
+		"terrainType": "LAND"
+	},
+	"26,24": {
+		"terrainType": "LAND"
+	},
+	"26,25": {
+		"terrainType": "LAND"
+	},
+	"26,26": {
+		"terrainType": "LAND"
+	},
+	"26,27": {
+		"terrainType": "LAND"
+	},
+	"26,28": {
+		"terrainType": "LAND"
+	},
+	"26,29": {
+		"terrainType": "LAND"
+	},
+	"26,30": {
+		"terrainType": "LAND"
+	},
+	"26,31": {
+		"terrainType": "LAND"
+	},
+	"26,32": {
+		"terrainType": "LAND"
+	},
+	"26,33": {
+		"terrainType": "LAND"
+	},
+	"26,34": {
+		"terrainType": "LAND"
+	},
+	"26,35": {
+		"terrainType": "LAND"
+	},
+	"26,36": {
+		"terrainType": "LAND"
+	},
+	"26,37": {
+		"terrainType": "LAND"
+	},
+	"26,38": {
+		"terrainType": "LAND"
+	},
+	"26,39": {
+		"terrainType": "LAND"
+	},
+	"26,40": {
+		"terrainType": "LAND"
+	},
+	"26,41": {
+		"terrainType": "LAND"
+	},
+	"26,42": {
+		"terrainType": "LAND"
+	},
+	"26,43": {
+		"terrainType": "LAND"
+	},
+	"26,44": {
+		"terrainType": "LAND"
+	},
+	"26,45": {
+		"terrainType": "LAND"
+	},
+	"26,46": {
+		"terrainType": "LAND"
+	},
+	"26,47": {
+		"terrainType": "LAND"
+	},
+	"26,48": {
+		"terrainType": "LAND"
+	},
+	"26,49": {
+		"terrainType": "LAND"
+	},
+	"26,50": {
+		"terrainType": "LAND"
+	},
+	"26,51": {
+		"terrainType": "LAND"
+	},
+	"26,52": {
+		"terrainType": "LAND"
+	},
+	"26,53": {
+		"terrainType": "LAND"
+	},
+	"26,54": {
+		"terrainType": "LAND"
+	},
+	"26,55": {
+		"terrainType": "LAND"
+	},
+	"26,56": {
+		"terrainType": "LAND"
+	},
+	"26,57": {
+		"terrainType": "LAND"
+	},
+	"26,58": {
+		"terrainType": "LAND"
+	},
+	"26,59": {
+		"terrainType": "LAND"
+	},
+	"26,60": {
+		"terrainType": "LAND"
+	},
+	"26,61": {
+		"terrainType": "LAND"
+	},
+	"26,62": {
+		"terrainType": "LAND"
+	},
+	"26,63": {
+		"terrainType": "LAND"
+	},
+	"27,0": {
+		"terrainType": "LAND"
+	},
+	"27,1": {
+		"terrainType": "LAND"
+	},
+	"27,2": {
+		"terrainType": "LAND"
+	},
+	"27,3": {
+		"terrainType": "LAND"
+	},
+	"27,4": {
+		"terrainType": "LAND"
+	},
+	"27,5": {
+		"terrainType": "LAND"
+	},
+	"27,6": {
+		"terrainType": "LAND"
+	},
+	"27,7": {
+		"terrainType": "LAND"
+	},
+	"27,8": {
+		"terrainType": "LAND"
+	},
+	"27,9": {
+		"terrainType": "LAND"
+	},
+	"27,10": {
+		"terrainType": "LAND"
+	},
+	"27,11": {
+		"terrainType": "LAND"
+	},
+	"27,12": {
+		"terrainType": "LAND"
+	},
+	"27,13": {
+		"terrainType": "LAND"
+	},
+	"27,14": {
+		"terrainType": "LAND"
+	},
+	"27,15": {
+		"terrainType": "LAND"
+	},
+	"27,16": {
+		"terrainType": "LAND"
+	},
+	"27,17": {
+		"terrainType": "LAND"
+	},
+	"27,18": {
+		"terrainType": "LAND"
+	},
+	"27,19": {
+		"terrainType": "LAND"
+	},
+	"27,20": {
+		"terrainType": "LAND"
+	},
+	"27,21": {
+		"terrainType": "LAND"
+	},
+	"27,22": {
+		"terrainType": "LAND"
+	},
+	"27,23": {
+		"terrainType": "LAND"
+	},
+	"27,24": {
+		"terrainType": "LAND"
+	},
+	"27,25": {
+		"terrainType": "LAND"
+	},
+	"27,26": {
+		"terrainType": "LAND"
+	},
+	"27,27": {
+		"terrainType": "LAND"
+	},
+	"27,28": {
+		"terrainType": "LAND"
+	},
+	"27,29": {
+		"terrainType": "LAND"
+	},
+	"27,30": {
+		"terrainType": "LAND"
+	},
+	"27,31": {
+		"terrainType": "LAND"
+	},
+	"27,32": {
+		"terrainType": "LAND"
+	},
+	"27,33": {
+		"terrainType": "LAND"
+	},
+	"27,34": {
+		"terrainType": "LAND"
+	},
+	"27,35": {
+		"terrainType": "LAND"
+	},
+	"27,36": {
+		"terrainType": "LAND"
+	},
+	"27,37": {
+		"terrainType": "LAND"
+	},
+	"27,38": {
+		"terrainType": "LAND"
+	},
+	"27,39": {
+		"terrainType": "LAND"
+	},
+	"27,40": {
+		"terrainType": "LAND"
+	},
+	"27,41": {
+		"terrainType": "LAND"
+	},
+	"27,42": {
+		"terrainType": "LAND"
+	},
+	"27,43": {
+		"terrainType": "LAND"
+	},
+	"27,44": {
+		"terrainType": "LAND"
+	},
+	"27,45": {
+		"terrainType": "LAND"
+	},
+	"27,46": {
+		"terrainType": "LAND"
+	},
+	"27,47": {
+		"terrainType": "LAND"
+	},
+	"27,48": {
+		"terrainType": "LAND"
+	},
+	"27,49": {
+		"terrainType": "LAND"
+	},
+	"27,50": {
+		"terrainType": "LAND"
+	},
+	"27,51": {
+		"terrainType": "LAND"
+	},
+	"27,52": {
+		"terrainType": "LAND"
+	},
+	"27,53": {
+		"terrainType": "LAND"
+	},
+	"27,54": {
+		"terrainType": "LAND"
+	},
+	"27,55": {
+		"terrainType": "LAND"
+	},
+	"27,56": {
+		"terrainType": "LAND"
+	},
+	"27,57": {
+		"terrainType": "LAND"
+	},
+	"27,58": {
+		"terrainType": "LAND"
+	},
+	"27,59": {
+		"terrainType": "LAND"
+	},
+	"27,60": {
+		"terrainType": "LAND"
+	},
+	"27,61": {
+		"terrainType": "LAND"
+	},
+	"27,62": {
+		"terrainType": "LAND"
+	},
+	"27,63": {
+		"terrainType": "LAND"
+	},
+	"28,0": {
+		"terrainType": "LAND"
+	},
+	"28,1": {
+		"terrainType": "LAND"
+	},
+	"28,2": {
+		"terrainType": "LAND"
+	},
+	"28,3": {
+		"terrainType": "LAND"
+	},
+	"28,4": {
+		"terrainType": "LAND"
+	},
+	"28,5": {
+		"terrainType": "LAND"
+	},
+	"28,6": {
+		"terrainType": "LAND"
+	},
+	"28,7": {
+		"terrainType": "LAND"
+	},
+	"28,8": {
+		"terrainType": "LAND"
+	},
+	"28,9": {
+		"terrainType": "LAND"
+	},
+	"28,10": {
+		"terrainType": "LAND"
+	},
+	"28,11": {
+		"terrainType": "LAND"
+	},
+	"28,12": {
+		"terrainType": "LAND"
+	},
+	"28,13": {
+		"terrainType": "LAND"
+	},
+	"28,14": {
+		"terrainType": "LAND"
+	},
+	"28,15": {
+		"terrainType": "LAND"
+	},
+	"28,16": {
+		"terrainType": "LAND"
+	},
+	"28,17": {
+		"terrainType": "LAND"
+	},
+	"28,18": {
+		"terrainType": "LAND"
+	},
+	"28,19": {
+		"terrainType": "LAND"
+	},
+	"28,20": {
+		"terrainType": "LAND"
+	},
+	"28,21": {
+		"terrainType": "LAND"
+	},
+	"28,22": {
+		"terrainType": "LAND"
+	},
+	"28,23": {
+		"terrainType": "LAND"
+	},
+	"28,24": {
+		"terrainType": "LAND"
+	},
+	"28,25": {
+		"terrainType": "LAND"
+	},
+	"28,26": {
+		"terrainType": "LAND"
+	},
+	"28,27": {
+		"terrainType": "LAND"
+	},
+	"28,28": {
+		"terrainType": "LAND"
+	},
+	"28,29": {
+		"terrainType": "LAND"
+	},
+	"28,30": {
+		"terrainType": "LAND"
+	},
+	"28,31": {
+		"terrainType": "LAND"
+	},
+	"28,32": {
+		"terrainType": "LAND"
+	},
+	"28,33": {
+		"terrainType": "LAND"
+	},
+	"28,34": {
+		"terrainType": "LAND"
+	},
+	"28,35": {
+		"terrainType": "LAND"
+	},
+	"28,36": {
+		"terrainType": "LAND"
+	},
+	"28,37": {
+		"terrainType": "LAND"
+	},
+	"28,38": {
+		"terrainType": "LAND"
+	},
+	"28,39": {
+		"terrainType": "LAND"
+	},
+	"28,40": {
+		"terrainType": "LAND"
+	},
+	"28,41": {
+		"terrainType": "LAND"
+	},
+	"28,42": {
+		"terrainType": "LAND"
+	},
+	"28,43": {
+		"terrainType": "LAND"
+	},
+	"28,44": {
+		"terrainType": "LAND"
+	},
+	"28,45": {
+		"terrainType": "LAND"
+	},
+	"28,46": {
+		"terrainType": "LAND"
+	},
+	"28,47": {
+		"terrainType": "LAND"
+	},
+	"28,48": {
+		"terrainType": "LAND"
+	},
+	"28,49": {
+		"terrainType": "LAND"
+	},
+	"28,50": {
+		"terrainType": "LAND"
+	},
+	"28,51": {
+		"terrainType": "LAND"
+	},
+	"28,52": {
+		"terrainType": "LAND"
+	},
+	"28,53": {
+		"terrainType": "LAND"
+	},
+	"28,54": {
+		"terrainType": "LAND"
+	},
+	"28,55": {
+		"terrainType": "LAND"
+	},
+	"28,56": {
+		"terrainType": "LAND"
+	},
+	"28,57": {
+		"terrainType": "LAND"
+	},
+	"28,58": {
+		"terrainType": "LAND"
+	},
+	"28,59": {
+		"terrainType": "LAND"
+	},
+	"28,60": {
+		"terrainType": "LAND"
+	},
+	"28,61": {
+		"terrainType": "LAND"
+	},
+	"28,62": {
+		"terrainType": "LAND"
+	},
+	"28,63": {
+		"terrainType": "LAND"
+	},
+	"29,0": {
+		"terrainType": "LAND"
+	},
+	"29,1": {
+		"terrainType": "LAND"
+	},
+	"29,2": {
+		"terrainType": "LAND"
+	},
+	"29,3": {
+		"terrainType": "LAND"
+	},
+	"29,4": {
+		"terrainType": "LAND"
+	},
+	"29,5": {
+		"terrainType": "LAND"
+	},
+	"29,6": {
+		"terrainType": "LAND"
+	},
+	"29,7": {
+		"terrainType": "LAND"
+	},
+	"29,8": {
+		"terrainType": "LAND"
+	},
+	"29,9": {
+		"terrainType": "LAND"
+	},
+	"29,10": {
+		"terrainType": "LAND"
+	},
+	"29,11": {
+		"terrainType": "LAND"
+	},
+	"29,12": {
+		"terrainType": "LAND"
+	},
+	"29,13": {
+		"terrainType": "LAND"
+	},
+	"29,14": {
+		"terrainType": "LAND"
+	},
+	"29,15": {
+		"terrainType": "LAND"
+	},
+	"29,16": {
+		"terrainType": "LAND"
+	},
+	"29,17": {
+		"terrainType": "LAND"
+	},
+	"29,18": {
+		"terrainType": "LAND"
+	},
+	"29,19": {
+		"terrainType": "LAND"
+	},
+	"29,20": {
+		"terrainType": "LAND"
+	},
+	"29,21": {
+		"terrainType": "LAND"
+	},
+	"29,22": {
+		"terrainType": "LAND"
+	},
+	"29,23": {
+		"terrainType": "LAND"
+	},
+	"29,24": {
+		"terrainType": "LAND"
+	},
+	"29,25": {
+		"terrainType": "LAND"
+	},
+	"29,26": {
+		"terrainType": "LAND"
+	},
+	"29,27": {
+		"terrainType": "LAND"
+	},
+	"29,28": {
+		"terrainType": "LAND"
+	},
+	"29,29": {
+		"terrainType": "LAND"
+	},
+	"29,30": {
+		"terrainType": "LAND"
+	},
+	"29,31": {
+		"terrainType": "LAND"
+	},
+	"29,32": {
+		"terrainType": "LAND"
+	},
+	"29,33": {
+		"terrainType": "LAND"
+	},
+	"29,34": {
+		"terrainType": "LAND"
+	},
+	"29,35": {
+		"terrainType": "LAND"
+	},
+	"29,36": {
+		"terrainType": "LAND"
+	},
+	"29,37": {
+		"terrainType": "LAND"
+	},
+	"29,38": {
+		"terrainType": "LAND"
+	},
+	"29,39": {
+		"terrainType": "LAND"
+	},
+	"29,40": {
+		"terrainType": "LAND"
+	},
+	"29,41": {
+		"terrainType": "LAND"
+	},
+	"29,42": {
+		"terrainType": "LAND"
+	},
+	"29,43": {
+		"terrainType": "LAND"
+	},
+	"29,44": {
+		"terrainType": "LAND"
+	},
+	"29,45": {
+		"terrainType": "LAND"
+	},
+	"29,46": {
+		"terrainType": "LAND"
+	},
+	"29,47": {
+		"terrainType": "LAND"
+	},
+	"29,48": {
+		"terrainType": "LAND"
+	},
+	"29,49": {
+		"terrainType": "LAND"
+	},
+	"29,50": {
+		"terrainType": "LAND"
+	},
+	"29,51": {
+		"terrainType": "LAND"
+	},
+	"29,52": {
+		"terrainType": "LAND"
+	},
+	"29,53": {
+		"terrainType": "LAND"
+	},
+	"29,54": {
+		"terrainType": "LAND"
+	},
+	"29,55": {
+		"terrainType": "LAND"
+	},
+	"29,56": {
+		"terrainType": "LAND"
+	},
+	"29,57": {
+		"terrainType": "LAND"
+	},
+	"29,58": {
+		"terrainType": "LAND"
+	},
+	"29,59": {
+		"terrainType": "LAND"
+	},
+	"29,60": {
+		"terrainType": "LAND"
+	},
+	"29,61": {
+		"terrainType": "LAND"
+	},
+	"29,62": {
+		"terrainType": "LAND"
+	},
+	"29,63": {
+		"terrainType": "LAND"
+	},
+	"30,0": {
+		"terrainType": "LAND"
+	},
+	"30,1": {
+		"terrainType": "LAND"
+	},
+	"30,2": {
+		"terrainType": "LAND"
+	},
+	"30,3": {
+		"terrainType": "LAND"
+	},
+	"30,4": {
+		"terrainType": "LAND"
+	},
+	"30,5": {
+		"terrainType": "LAND"
+	},
+	"30,6": {
+		"terrainType": "LAND"
+	},
+	"30,7": {
+		"terrainType": "LAND"
+	},
+	"30,8": {
+		"terrainType": "LAND"
+	},
+	"30,9": {
+		"terrainType": "LAND"
+	},
+	"30,10": {
+		"terrainType": "LAND"
+	},
+	"30,11": {
+		"terrainType": "LAND"
+	},
+	"30,12": {
+		"terrainType": "LAND"
+	},
+	"30,13": {
+		"terrainType": "LAND"
+	},
+	"30,14": {
+		"terrainType": "LAND"
+	},
+	"30,15": {
+		"terrainType": "LAND"
+	},
+	"30,16": {
+		"terrainType": "LAND"
+	},
+	"30,17": {
+		"terrainType": "LAND"
+	},
+	"30,18": {
+		"terrainType": "LAND"
+	},
+	"30,19": {
+		"terrainType": "LAND"
+	},
+	"30,20": {
+		"terrainType": "LAND"
+	},
+	"30,21": {
+		"terrainType": "LAND"
+	},
+	"30,22": {
+		"terrainType": "LAND"
+	},
+	"30,23": {
+		"terrainType": "LAND"
+	},
+	"30,24": {
+		"terrainType": "LAND"
+	},
+	"30,25": {
+		"terrainType": "LAND"
+	},
+	"30,26": {
+		"terrainType": "LAND"
+	},
+	"30,27": {
+		"terrainType": "LAND"
+	},
+	"30,28": {
+		"terrainType": "LAND"
+	},
+	"30,29": {
+		"terrainType": "LAND"
+	},
+	"30,30": {
+		"terrainType": "LAND"
+	},
+	"30,31": {
+		"terrainType": "LAND"
+	},
+	"30,32": {
+		"terrainType": "LAND"
+	},
+	"30,33": {
+		"terrainType": "LAND"
+	},
+	"30,34": {
+		"terrainType": "LAND"
+	},
+	"30,35": {
+		"terrainType": "LAND"
+	},
+	"30,36": {
+		"terrainType": "LAND"
+	},
+	"30,37": {
+		"terrainType": "LAND"
+	},
+	"30,38": {
+		"terrainType": "LAND"
+	},
+	"30,39": {
+		"terrainType": "LAND"
+	},
+	"30,40": {
+		"terrainType": "LAND"
+	},
+	"30,41": {
+		"terrainType": "LAND"
+	},
+	"30,42": {
+		"terrainType": "LAND"
+	},
+	"30,43": {
+		"terrainType": "LAND"
+	},
+	"30,44": {
+		"terrainType": "LAND"
+	},
+	"30,45": {
+		"terrainType": "LAND"
+	},
+	"30,46": {
+		"terrainType": "LAND"
+	},
+	"30,47": {
+		"terrainType": "LAND"
+	},
+	"30,48": {
+		"terrainType": "LAND"
+	},
+	"30,49": {
+		"terrainType": "LAND"
+	},
+	"30,50": {
+		"terrainType": "LAND"
+	},
+	"30,51": {
+		"terrainType": "LAND"
+	},
+	"30,52": {
+		"terrainType": "LAND"
+	},
+	"30,53": {
+		"terrainType": "LAND"
+	},
+	"30,54": {
+		"terrainType": "LAND"
+	},
+	"30,55": {
+		"terrainType": "LAND"
+	},
+	"30,56": {
+		"terrainType": "LAND"
+	},
+	"30,57": {
+		"terrainType": "LAND"
+	},
+	"30,58": {
+		"terrainType": "LAND"
+	},
+	"30,59": {
+		"terrainType": "LAND"
+	},
+	"30,60": {
+		"terrainType": "LAND"
+	},
+	"30,61": {
+		"terrainType": "LAND"
+	},
+	"30,62": {
+		"terrainType": "LAND"
+	},
+	"30,63": {
+		"terrainType": "LAND"
+	},
+	"31,0": {
+		"terrainType": "LAND"
+	},
+	"31,1": {
+		"terrainType": "LAND"
+	},
+	"31,2": {
+		"terrainType": "LAND"
+	},
+	"31,3": {
+		"terrainType": "LAND"
+	},
+	"31,4": {
+		"terrainType": "LAND"
+	},
+	"31,5": {
+		"terrainType": "LAND"
+	},
+	"31,6": {
+		"terrainType": "LAND"
+	},
+	"31,7": {
+		"terrainType": "LAND"
+	},
+	"31,8": {
+		"terrainType": "LAND"
+	},
+	"31,9": {
+		"terrainType": "LAND"
+	},
+	"31,10": {
+		"terrainType": "LAND"
+	},
+	"31,11": {
+		"terrainType": "LAND"
+	},
+	"31,12": {
+		"terrainType": "LAND"
+	},
+	"31,13": {
+		"terrainType": "LAND"
+	},
+	"31,14": {
+		"terrainType": "LAND"
+	},
+	"31,15": {
+		"terrainType": "LAND"
+	},
+	"31,16": {
+		"terrainType": "LAND"
+	},
+	"31,17": {
+		"terrainType": "LAND"
+	},
+	"31,18": {
+		"terrainType": "LAND"
+	},
+	"31,19": {
+		"terrainType": "LAND"
+	},
+	"31,20": {
+		"terrainType": "LAND"
+	},
+	"31,21": {
+		"terrainType": "LAND"
+	},
+	"31,22": {
+		"terrainType": "LAND"
+	},
+	"31,23": {
+		"terrainType": "LAND"
+	},
+	"31,24": {
+		"terrainType": "LAND"
+	},
+	"31,25": {
+		"terrainType": "LAND"
+	},
+	"31,26": {
+		"terrainType": "LAND"
+	},
+	"31,27": {
+		"terrainType": "LAND"
+	},
+	"31,28": {
+		"terrainType": "LAND"
+	},
+	"31,29": {
+		"terrainType": "LAND"
+	},
+	"31,30": {
+		"terrainType": "LAND"
+	},
+	"31,31": {
+		"terrainType": "LAND"
+	},
+	"31,32": {
+		"terrainType": "LAND"
+	},
+	"31,33": {
+		"terrainType": "LAND"
+	},
+	"31,34": {
+		"terrainType": "LAND"
+	},
+	"31,35": {
+		"terrainType": "LAND"
+	},
+	"31,36": {
+		"terrainType": "LAND"
+	},
+	"31,37": {
+		"terrainType": "LAND"
+	},
+	"31,38": {
+		"terrainType": "LAND"
+	},
+	"31,39": {
+		"terrainType": "LAND"
+	},
+	"31,40": {
+		"terrainType": "LAND"
+	},
+	"31,41": {
+		"terrainType": "LAND"
+	},
+	"31,42": {
+		"terrainType": "LAND"
+	},
+	"31,43": {
+		"terrainType": "LAND"
+	},
+	"31,44": {
+		"terrainType": "LAND"
+	},
+	"31,45": {
+		"terrainType": "LAND"
+	},
+	"31,46": {
+		"terrainType": "LAND"
+	},
+	"31,47": {
+		"terrainType": "LAND"
+	},
+	"31,48": {
+		"terrainType": "LAND"
+	},
+	"31,49": {
+		"terrainType": "LAND"
+	},
+	"31,50": {
+		"terrainType": "LAND"
+	},
+	"31,51": {
+		"terrainType": "LAND"
+	},
+	"31,52": {
+		"terrainType": "LAND"
+	},
+	"31,53": {
+		"terrainType": "LAND"
+	},
+	"31,54": {
+		"terrainType": "LAND"
+	},
+	"31,55": {
+		"terrainType": "LAND"
+	},
+	"31,56": {
+		"terrainType": "LAND"
+	},
+	"31,57": {
+		"terrainType": "LAND"
+	},
+	"31,58": {
+		"terrainType": "LAND"
+	},
+	"31,59": {
+		"terrainType": "LAND"
+	},
+	"31,60": {
+		"terrainType": "LAND"
+	},
+	"31,61": {
+		"terrainType": "LAND"
+	},
+	"31,62": {
+		"terrainType": "LAND"
+	},
+	"31,63": {
+		"terrainType": "LAND"
+	},
+	"32,0": {
+		"terrainType": "LAND"
+	},
+	"32,1": {
+		"terrainType": "LAND"
+	},
+	"32,2": {
+		"terrainType": "LAND"
+	},
+	"32,3": {
+		"terrainType": "LAND"
+	},
+	"32,4": {
+		"terrainType": "LAND"
+	},
+	"32,5": {
+		"terrainType": "LAND"
+	},
+	"32,6": {
+		"terrainType": "LAND"
+	},
+	"32,7": {
+		"terrainType": "LAND"
+	},
+	"32,8": {
+		"terrainType": "LAND"
+	},
+	"32,9": {
+		"terrainType": "LAND"
+	},
+	"32,10": {
+		"terrainType": "LAND"
+	},
+	"32,11": {
+		"terrainType": "LAND"
+	},
+	"32,12": {
+		"terrainType": "LAND"
+	},
+	"32,13": {
+		"terrainType": "LAND"
+	},
+	"32,14": {
+		"terrainType": "LAND"
+	},
+	"32,15": {
+		"terrainType": "LAND"
+	},
+	"32,16": {
+		"terrainType": "LAND"
+	},
+	"32,17": {
+		"terrainType": "LAND"
+	},
+	"32,18": {
+		"terrainType": "LAND"
+	},
+	"32,19": {
+		"terrainType": "LAND"
+	},
+	"32,20": {
+		"terrainType": "LAND"
+	},
+	"32,21": {
+		"terrainType": "LAND"
+	},
+	"32,22": {
+		"terrainType": "LAND"
+	},
+	"32,23": {
+		"terrainType": "LAND"
+	},
+	"32,24": {
+		"terrainType": "LAND"
+	},
+	"32,25": {
+		"terrainType": "LAND"
+	},
+	"32,26": {
+		"terrainType": "LAND"
+	},
+	"32,27": {
+		"terrainType": "LAND"
+	},
+	"32,28": {
+		"terrainType": "LAND"
+	},
+	"32,29": {
+		"terrainType": "LAND"
+	},
+	"32,30": {
+		"terrainType": "LAND"
+	},
+	"32,31": {
+		"terrainType": "LAND"
+	},
+	"32,32": {
+		"terrainType": "LAND"
+	},
+	"32,33": {
+		"terrainType": "LAND"
+	},
+	"32,34": {
+		"terrainType": "LAND"
+	},
+	"32,35": {
+		"terrainType": "LAND"
+	},
+	"32,36": {
+		"terrainType": "LAND"
+	},
+	"32,37": {
+		"terrainType": "LAND"
+	},
+	"32,38": {
+		"terrainType": "LAND"
+	},
+	"32,39": {
+		"terrainType": "LAND"
+	},
+	"32,40": {
+		"terrainType": "LAND"
+	},
+	"32,41": {
+		"terrainType": "LAND"
+	},
+	"32,42": {
+		"terrainType": "LAND"
+	},
+	"32,43": {
+		"terrainType": "LAND"
+	},
+	"32,44": {
+		"terrainType": "LAND"
+	},
+	"32,45": {
+		"terrainType": "LAND"
+	},
+	"32,46": {
+		"terrainType": "LAND"
+	},
+	"32,47": {
+		"terrainType": "LAND"
+	},
+	"32,48": {
+		"terrainType": "LAND"
+	},
+	"32,49": {
+		"terrainType": "LAND"
+	},
+	"32,50": {
+		"terrainType": "LAND"
+	},
+	"32,51": {
+		"terrainType": "LAND"
+	},
+	"32,52": {
+		"terrainType": "LAND"
+	},
+	"32,53": {
+		"terrainType": "LAND"
+	},
+	"32,54": {
+		"terrainType": "LAND"
+	},
+	"32,55": {
+		"terrainType": "LAND"
+	},
+	"32,56": {
+		"terrainType": "LAND"
+	},
+	"32,57": {
+		"terrainType": "LAND"
+	},
+	"32,58": {
+		"terrainType": "LAND"
+	},
+	"32,59": {
+		"terrainType": "LAND"
+	},
+	"32,60": {
+		"terrainType": "LAND"
+	},
+	"32,61": {
+		"terrainType": "LAND"
+	},
+	"32,62": {
+		"terrainType": "LAND"
+	},
+	"32,63": {
+		"terrainType": "LAND"
+	},
+	"33,0": {
+		"terrainType": "LAND"
+	},
+	"33,1": {
+		"terrainType": "LAND"
+	},
+	"33,2": {
+		"terrainType": "LAND"
+	},
+	"33,3": {
+		"terrainType": "LAND"
+	},
+	"33,4": {
+		"terrainType": "LAND"
+	},
+	"33,5": {
+		"terrainType": "LAND"
+	},
+	"33,6": {
+		"terrainType": "LAND"
+	},
+	"33,7": {
+		"terrainType": "LAND"
+	},
+	"33,8": {
+		"terrainType": "LAND"
+	},
+	"33,9": {
+		"terrainType": "LAND"
+	},
+	"33,10": {
+		"terrainType": "LAND"
+	},
+	"33,11": {
+		"terrainType": "LAND"
+	},
+	"33,12": {
+		"terrainType": "LAND"
+	},
+	"33,13": {
+		"terrainType": "LAND"
+	},
+	"33,14": {
+		"terrainType": "LAND"
+	},
+	"33,15": {
+		"terrainType": "LAND"
+	},
+	"33,16": {
+		"terrainType": "LAND"
+	},
+	"33,17": {
+		"terrainType": "LAND"
+	},
+	"33,18": {
+		"terrainType": "LAND"
+	},
+	"33,19": {
+		"terrainType": "LAND"
+	},
+	"33,20": {
+		"terrainType": "LAND"
+	},
+	"33,21": {
+		"terrainType": "LAND"
+	},
+	"33,22": {
+		"terrainType": "LAND"
+	},
+	"33,23": {
+		"terrainType": "LAND"
+	},
+	"33,24": {
+		"terrainType": "LAND"
+	},
+	"33,25": {
+		"terrainType": "LAND"
+	},
+	"33,26": {
+		"terrainType": "LAND"
+	},
+	"33,27": {
+		"terrainType": "LAND"
+	},
+	"33,28": {
+		"terrainType": "LAND"
+	},
+	"33,29": {
+		"terrainType": "LAND"
+	},
+	"33,30": {
+		"terrainType": "LAND"
+	},
+	"33,31": {
+		"terrainType": "LAND"
+	},
+	"33,32": {
+		"terrainType": "LAND"
+	},
+	"33,33": {
+		"terrainType": "LAND"
+	},
+	"33,34": {
+		"terrainType": "LAND"
+	},
+	"33,35": {
+		"terrainType": "LAND"
+	},
+	"33,36": {
+		"terrainType": "LAND"
+	},
+	"33,37": {
+		"terrainType": "LAND"
+	},
+	"33,38": {
+		"terrainType": "LAND"
+	},
+	"33,39": {
+		"terrainType": "LAND"
+	},
+	"33,40": {
+		"terrainType": "LAND"
+	},
+	"33,41": {
+		"terrainType": "LAND"
+	},
+	"33,42": {
+		"terrainType": "LAND"
+	},
+	"33,43": {
+		"terrainType": "LAND"
+	},
+	"33,44": {
+		"terrainType": "LAND"
+	},
+	"33,45": {
+		"terrainType": "LAND"
+	},
+	"33,46": {
+		"terrainType": "LAND"
+	},
+	"33,47": {
+		"terrainType": "LAND"
+	},
+	"33,48": {
+		"terrainType": "LAND"
+	},
+	"33,49": {
+		"terrainType": "LAND"
+	},
+	"33,50": {
+		"terrainType": "LAND"
+	},
+	"33,51": {
+		"terrainType": "LAND"
+	},
+	"33,52": {
+		"terrainType": "LAND"
+	},
+	"33,53": {
+		"terrainType": "LAND"
+	},
+	"33,54": {
+		"terrainType": "LAND"
+	},
+	"33,55": {
+		"terrainType": "LAND"
+	},
+	"33,56": {
+		"terrainType": "LAND"
+	},
+	"33,57": {
+		"terrainType": "LAND"
+	},
+	"33,58": {
+		"terrainType": "LAND"
+	},
+	"33,59": {
+		"terrainType": "LAND"
+	},
+	"33,60": {
+		"terrainType": "LAND"
+	},
+	"33,61": {
+		"terrainType": "LAND"
+	},
+	"33,62": {
+		"terrainType": "LAND"
+	},
+	"33,63": {
+		"terrainType": "LAND"
+	},
+	"34,0": {
+		"terrainType": "LAND"
+	},
+	"34,1": {
+		"terrainType": "LAND"
+	},
+	"34,2": {
+		"terrainType": "LAND"
+	},
+	"34,3": {
+		"terrainType": "LAND"
+	},
+	"34,4": {
+		"terrainType": "LAND"
+	},
+	"34,5": {
+		"terrainType": "LAND"
+	},
+	"34,6": {
+		"terrainType": "LAND"
+	},
+	"34,7": {
+		"terrainType": "LAND"
+	},
+	"34,8": {
+		"terrainType": "LAND"
+	},
+	"34,9": {
+		"terrainType": "LAND"
+	},
+	"34,10": {
+		"terrainType": "LAND"
+	},
+	"34,11": {
+		"terrainType": "LAND"
+	},
+	"34,12": {
+		"terrainType": "LAND"
+	},
+	"34,13": {
+		"terrainType": "LAND"
+	},
+	"34,14": {
+		"terrainType": "LAND"
+	},
+	"34,15": {
+		"terrainType": "LAND"
+	},
+	"34,16": {
+		"terrainType": "LAND"
+	},
+	"34,17": {
+		"terrainType": "LAND"
+	},
+	"34,18": {
+		"terrainType": "LAND"
+	},
+	"34,19": {
+		"terrainType": "LAND"
+	},
+	"34,20": {
+		"terrainType": "LAND"
+	},
+	"34,21": {
+		"terrainType": "LAND"
+	},
+	"34,22": {
+		"terrainType": "LAND"
+	},
+	"34,23": {
+		"terrainType": "LAND"
+	},
+	"34,24": {
+		"terrainType": "LAND"
+	},
+	"34,25": {
+		"terrainType": "LAND"
+	},
+	"34,26": {
+		"terrainType": "LAND"
+	},
+	"34,27": {
+		"terrainType": "LAND"
+	},
+	"34,28": {
+		"terrainType": "LAND"
+	},
+	"34,29": {
+		"terrainType": "LAND"
+	},
+	"34,30": {
+		"terrainType": "LAND"
+	},
+	"34,31": {
+		"terrainType": "LAND"
+	},
+	"34,32": {
+		"terrainType": "LAND"
+	},
+	"34,33": {
+		"terrainType": "LAND"
+	},
+	"34,34": {
+		"terrainType": "LAND"
+	},
+	"34,35": {
+		"terrainType": "LAND"
+	},
+	"34,36": {
+		"terrainType": "LAND"
+	},
+	"34,37": {
+		"terrainType": "LAND"
+	},
+	"34,38": {
+		"terrainType": "LAND"
+	},
+	"34,39": {
+		"terrainType": "LAND"
+	},
+	"34,40": {
+		"terrainType": "LAND"
+	},
+	"34,41": {
+		"terrainType": "LAND"
+	},
+	"34,42": {
+		"terrainType": "LAND"
+	},
+	"34,43": {
+		"terrainType": "LAND"
+	},
+	"34,44": {
+		"terrainType": "LAND"
+	},
+	"34,45": {
+		"terrainType": "LAND"
+	},
+	"34,46": {
+		"terrainType": "LAND"
+	},
+	"34,47": {
+		"terrainType": "LAND"
+	},
+	"34,48": {
+		"terrainType": "LAND"
+	},
+	"34,49": {
+		"terrainType": "LAND"
+	},
+	"34,50": {
+		"terrainType": "LAND"
+	},
+	"34,51": {
+		"terrainType": "LAND"
+	},
+	"34,52": {
+		"terrainType": "LAND"
+	},
+	"34,53": {
+		"terrainType": "LAND"
+	},
+	"34,54": {
+		"terrainType": "LAND"
+	},
+	"34,55": {
+		"terrainType": "LAND"
+	},
+	"34,56": {
+		"terrainType": "LAND"
+	},
+	"34,57": {
+		"terrainType": "LAND"
+	},
+	"34,58": {
+		"terrainType": "LAND"
+	},
+	"34,59": {
+		"terrainType": "LAND"
+	},
+	"34,60": {
+		"terrainType": "LAND"
+	},
+	"34,61": {
+		"terrainType": "LAND"
+	},
+	"34,62": {
+		"terrainType": "LAND"
+	},
+	"34,63": {
+		"terrainType": "LAND"
+	},
+	"35,0": {
+		"terrainType": "LAND"
+	},
+	"35,1": {
+		"terrainType": "LAND"
+	},
+	"35,2": {
+		"terrainType": "LAND"
+	},
+	"35,3": {
+		"terrainType": "LAND"
+	},
+	"35,4": {
+		"terrainType": "LAND"
+	},
+	"35,5": {
+		"terrainType": "LAND"
+	},
+	"35,6": {
+		"terrainType": "LAND"
+	},
+	"35,7": {
+		"terrainType": "LAND"
+	},
+	"35,8": {
+		"terrainType": "LAND"
+	},
+	"35,9": {
+		"terrainType": "LAND"
+	},
+	"35,10": {
+		"terrainType": "LAND"
+	},
+	"35,11": {
+		"terrainType": "LAND"
+	},
+	"35,12": {
+		"terrainType": "LAND"
+	},
+	"35,13": {
+		"terrainType": "LAND"
+	},
+	"35,14": {
+		"terrainType": "LAND"
+	},
+	"35,15": {
+		"terrainType": "LAND"
+	},
+	"35,16": {
+		"terrainType": "LAND"
+	},
+	"35,17": {
+		"terrainType": "LAND"
+	},
+	"35,18": {
+		"terrainType": "LAND"
+	},
+	"35,19": {
+		"terrainType": "LAND"
+	},
+	"35,20": {
+		"terrainType": "LAND"
+	},
+	"35,21": {
+		"terrainType": "LAND"
+	},
+	"35,22": {
+		"terrainType": "LAND"
+	},
+	"35,23": {
+		"terrainType": "LAND"
+	},
+	"35,24": {
+		"terrainType": "LAND"
+	},
+	"35,25": {
+		"terrainType": "LAND"
+	},
+	"35,26": {
+		"terrainType": "LAND"
+	},
+	"35,27": {
+		"terrainType": "LAND"
+	},
+	"35,28": {
+		"terrainType": "LAND"
+	},
+	"35,29": {
+		"terrainType": "LAND"
+	},
+	"35,30": {
+		"terrainType": "LAND"
+	},
+	"35,31": {
+		"terrainType": "LAND"
+	},
+	"35,32": {
+		"terrainType": "LAND"
+	},
+	"35,33": {
+		"terrainType": "LAND"
+	},
+	"35,34": {
+		"terrainType": "LAND"
+	},
+	"35,35": {
+		"terrainType": "LAND"
+	},
+	"35,36": {
+		"terrainType": "LAND"
+	},
+	"35,37": {
+		"terrainType": "LAND"
+	},
+	"35,38": {
+		"terrainType": "LAND"
+	},
+	"35,39": {
+		"terrainType": "LAND"
+	},
+	"35,40": {
+		"terrainType": "LAND"
+	},
+	"35,41": {
+		"terrainType": "LAND"
+	},
+	"35,42": {
+		"terrainType": "LAND"
+	},
+	"35,43": {
+		"terrainType": "LAND"
+	},
+	"35,44": {
+		"terrainType": "LAND"
+	},
+	"35,45": {
+		"terrainType": "LAND"
+	},
+	"35,46": {
+		"terrainType": "LAND"
+	},
+	"35,47": {
+		"terrainType": "LAND"
+	},
+	"35,48": {
+		"terrainType": "LAND"
+	},
+	"35,49": {
+		"terrainType": "LAND"
+	},
+	"35,50": {
+		"terrainType": "LAND"
+	},
+	"35,51": {
+		"terrainType": "LAND"
+	},
+	"35,52": {
+		"terrainType": "LAND"
+	},
+	"35,53": {
+		"terrainType": "LAND"
+	},
+	"35,54": {
+		"terrainType": "LAND"
+	},
+	"35,55": {
+		"terrainType": "LAND"
+	},
+	"35,56": {
+		"terrainType": "LAND"
+	},
+	"35,57": {
+		"terrainType": "LAND"
+	},
+	"35,58": {
+		"terrainType": "LAND"
+	},
+	"35,59": {
+		"terrainType": "LAND"
+	},
+	"35,60": {
+		"terrainType": "LAND"
+	},
+	"35,61": {
+		"terrainType": "LAND"
+	},
+	"35,62": {
+		"terrainType": "LAND"
+	},
+	"35,63": {
+		"terrainType": "LAND"
+	},
+	"36,0": {
+		"terrainType": "LAND"
+	},
+	"36,1": {
+		"terrainType": "LAND"
+	},
+	"36,2": {
+		"terrainType": "LAND"
+	},
+	"36,3": {
+		"terrainType": "LAND"
+	},
+	"36,4": {
+		"terrainType": "LAND"
+	},
+	"36,5": {
+		"terrainType": "LAND"
+	},
+	"36,6": {
+		"terrainType": "LAND"
+	},
+	"36,7": {
+		"terrainType": "LAND"
+	},
+	"36,8": {
+		"terrainType": "LAND"
+	},
+	"36,9": {
+		"terrainType": "LAND"
+	},
+	"36,10": {
+		"terrainType": "LAND"
+	},
+	"36,11": {
+		"terrainType": "LAND"
+	},
+	"36,12": {
+		"terrainType": "LAND"
+	},
+	"36,13": {
+		"terrainType": "LAND"
+	},
+	"36,14": {
+		"terrainType": "LAND"
+	},
+	"36,15": {
+		"terrainType": "LAND"
+	},
+	"36,16": {
+		"terrainType": "LAND"
+	},
+	"36,17": {
+		"terrainType": "LAND"
+	},
+	"36,18": {
+		"terrainType": "LAND"
+	},
+	"36,19": {
+		"terrainType": "LAND"
+	},
+	"36,20": {
+		"terrainType": "LAND"
+	},
+	"36,21": {
+		"terrainType": "LAND"
+	},
+	"36,22": {
+		"terrainType": "LAND"
+	},
+	"36,23": {
+		"terrainType": "LAND"
+	},
+	"36,24": {
+		"terrainType": "LAND"
+	},
+	"36,25": {
+		"terrainType": "LAND"
+	},
+	"36,26": {
+		"terrainType": "LAND"
+	},
+	"36,27": {
+		"terrainType": "LAND"
+	},
+	"36,28": {
+		"terrainType": "LAND"
+	},
+	"36,29": {
+		"terrainType": "LAND"
+	},
+	"36,30": {
+		"terrainType": "LAND"
+	},
+	"36,31": {
+		"terrainType": "LAND"
+	},
+	"36,32": {
+		"terrainType": "LAND"
+	},
+	"36,33": {
+		"terrainType": "LAND"
+	},
+	"36,34": {
+		"terrainType": "LAND"
+	},
+	"36,35": {
+		"terrainType": "LAND"
+	},
+	"36,36": {
+		"terrainType": "LAND"
+	},
+	"36,37": {
+		"terrainType": "LAND"
+	},
+	"36,38": {
+		"terrainType": "LAND"
+	},
+	"36,39": {
+		"terrainType": "LAND"
+	},
+	"36,40": {
+		"terrainType": "LAND"
+	},
+	"36,41": {
+		"terrainType": "LAND"
+	},
+	"36,42": {
+		"terrainType": "LAND"
+	},
+	"36,43": {
+		"terrainType": "LAND"
+	},
+	"36,44": {
+		"terrainType": "LAND"
+	},
+	"36,45": {
+		"terrainType": "LAND"
+	},
+	"36,46": {
+		"terrainType": "LAND"
+	},
+	"36,47": {
+		"terrainType": "LAND"
+	},
+	"36,48": {
+		"terrainType": "LAND"
+	},
+	"36,49": {
+		"terrainType": "LAND"
+	},
+	"36,50": {
+		"terrainType": "LAND"
+	},
+	"36,51": {
+		"terrainType": "LAND"
+	},
+	"36,52": {
+		"terrainType": "LAND"
+	},
+	"36,53": {
+		"terrainType": "LAND"
+	},
+	"36,54": {
+		"terrainType": "LAND"
+	},
+	"36,55": {
+		"terrainType": "LAND"
+	},
+	"36,56": {
+		"terrainType": "LAND"
+	},
+	"36,57": {
+		"terrainType": "LAND"
+	},
+	"36,58": {
+		"terrainType": "LAND"
+	},
+	"36,59": {
+		"terrainType": "LAND"
+	},
+	"36,60": {
+		"terrainType": "LAND"
+	},
+	"36,61": {
+		"terrainType": "LAND"
+	},
+	"36,62": {
+		"terrainType": "LAND"
+	},
+	"36,63": {
+		"terrainType": "LAND"
+	},
+	"37,0": {
+		"terrainType": "LAND"
+	},
+	"37,1": {
+		"terrainType": "LAND"
+	},
+	"37,2": {
+		"terrainType": "LAND"
+	},
+	"37,3": {
+		"terrainType": "LAND"
+	},
+	"37,4": {
+		"terrainType": "LAND"
+	},
+	"37,5": {
+		"terrainType": "LAND"
+	},
+	"37,6": {
+		"terrainType": "LAND"
+	},
+	"37,7": {
+		"terrainType": "LAND"
+	},
+	"37,8": {
+		"terrainType": "LAND"
+	},
+	"37,9": {
+		"terrainType": "LAND"
+	},
+	"37,10": {
+		"terrainType": "LAND"
+	},
+	"37,11": {
+		"terrainType": "LAND"
+	},
+	"37,12": {
+		"terrainType": "LAND"
+	},
+	"37,13": {
+		"terrainType": "LAND"
+	},
+	"37,14": {
+		"terrainType": "LAND"
+	},
+	"37,15": {
+		"terrainType": "LAND"
+	},
+	"37,16": {
+		"terrainType": "LAND"
+	},
+	"37,17": {
+		"terrainType": "LAND"
+	},
+	"37,18": {
+		"terrainType": "LAND"
+	},
+	"37,19": {
+		"terrainType": "LAND"
+	},
+	"37,20": {
+		"terrainType": "LAND"
+	},
+	"37,21": {
+		"terrainType": "LAND"
+	},
+	"37,22": {
+		"terrainType": "LAND"
+	},
+	"37,23": {
+		"terrainType": "LAND"
+	},
+	"37,24": {
+		"terrainType": "LAND"
+	},
+	"37,25": {
+		"terrainType": "LAND"
+	},
+	"37,26": {
+		"terrainType": "LAND"
+	},
+	"37,27": {
+		"terrainType": "LAND"
+	},
+	"37,28": {
+		"terrainType": "LAND"
+	},
+	"37,29": {
+		"terrainType": "LAND"
+	},
+	"37,30": {
+		"terrainType": "LAND"
+	},
+	"37,31": {
+		"terrainType": "LAND"
+	},
+	"37,32": {
+		"terrainType": "LAND"
+	},
+	"37,33": {
+		"terrainType": "LAND"
+	},
+	"37,34": {
+		"terrainType": "LAND"
+	},
+	"37,35": {
+		"terrainType": "LAND"
+	},
+	"37,36": {
+		"terrainType": "LAND"
+	},
+	"37,37": {
+		"terrainType": "LAND"
+	},
+	"37,38": {
+		"terrainType": "LAND"
+	},
+	"37,39": {
+		"terrainType": "LAND"
+	},
+	"37,40": {
+		"terrainType": "LAND"
+	},
+	"37,41": {
+		"terrainType": "LAND"
+	},
+	"37,42": {
+		"terrainType": "LAND"
+	},
+	"37,43": {
+		"terrainType": "LAND"
+	},
+	"37,44": {
+		"terrainType": "LAND"
+	},
+	"37,45": {
+		"terrainType": "LAND"
+	},
+	"37,46": {
+		"terrainType": "LAND"
+	},
+	"37,47": {
+		"terrainType": "LAND"
+	},
+	"37,48": {
+		"terrainType": "LAND"
+	},
+	"37,49": {
+		"terrainType": "LAND"
+	},
+	"37,50": {
+		"terrainType": "LAND"
+	},
+	"37,51": {
+		"terrainType": "LAND"
+	},
+	"37,52": {
+		"terrainType": "LAND"
+	},
+	"37,53": {
+		"terrainType": "LAND"
+	},
+	"37,54": {
+		"terrainType": "LAND"
+	},
+	"37,55": {
+		"terrainType": "LAND"
+	},
+	"37,56": {
+		"terrainType": "LAND"
+	},
+	"37,57": {
+		"terrainType": "LAND"
+	},
+	"37,58": {
+		"terrainType": "LAND"
+	},
+	"37,59": {
+		"terrainType": "LAND"
+	},
+	"37,60": {
+		"terrainType": "LAND"
+	},
+	"37,61": {
+		"terrainType": "LAND"
+	},
+	"37,62": {
+		"terrainType": "LAND"
+	},
+	"37,63": {
+		"terrainType": "LAND"
+	},
+	"38,0": {
+		"terrainType": "LAND"
+	},
+	"38,1": {
+		"terrainType": "LAND"
+	},
+	"38,2": {
+		"terrainType": "LAND"
+	},
+	"38,3": {
+		"terrainType": "LAND"
+	},
+	"38,4": {
+		"terrainType": "LAND"
+	},
+	"38,5": {
+		"terrainType": "LAND"
+	},
+	"38,6": {
+		"terrainType": "LAND"
+	},
+	"38,7": {
+		"terrainType": "LAND"
+	},
+	"38,8": {
+		"terrainType": "LAND"
+	},
+	"38,9": {
+		"terrainType": "LAND"
+	},
+	"38,10": {
+		"terrainType": "LAND"
+	},
+	"38,11": {
+		"terrainType": "LAND"
+	},
+	"38,12": {
+		"terrainType": "LAND"
+	},
+	"38,13": {
+		"terrainType": "LAND"
+	},
+	"38,14": {
+		"terrainType": "LAND"
+	},
+	"38,15": {
+		"terrainType": "LAND"
+	},
+	"38,16": {
+		"terrainType": "LAND"
+	},
+	"38,17": {
+		"terrainType": "LAND"
+	},
+	"38,18": {
+		"terrainType": "LAND"
+	},
+	"38,19": {
+		"terrainType": "LAND"
+	},
+	"38,20": {
+		"terrainType": "LAND"
+	},
+	"38,21": {
+		"terrainType": "LAND"
+	},
+	"38,22": {
+		"terrainType": "LAND"
+	},
+	"38,23": {
+		"terrainType": "LAND"
+	},
+	"38,24": {
+		"terrainType": "LAND"
+	},
+	"38,25": {
+		"terrainType": "LAND"
+	},
+	"38,26": {
+		"terrainType": "LAND"
+	},
+	"38,27": {
+		"terrainType": "LAND"
+	},
+	"38,28": {
+		"terrainType": "LAND"
+	},
+	"38,29": {
+		"terrainType": "LAND"
+	},
+	"38,30": {
+		"terrainType": "LAND"
+	},
+	"38,31": {
+		"terrainType": "LAND"
+	},
+	"38,32": {
+		"terrainType": "LAND"
+	},
+	"38,33": {
+		"terrainType": "LAND"
+	},
+	"38,34": {
+		"terrainType": "LAND"
+	},
+	"38,35": {
+		"terrainType": "LAND"
+	},
+	"38,36": {
+		"terrainType": "LAND"
+	},
+	"38,37": {
+		"terrainType": "LAND"
+	},
+	"38,38": {
+		"terrainType": "LAND"
+	},
+	"38,39": {
+		"terrainType": "LAND"
+	},
+	"38,40": {
+		"terrainType": "LAND"
+	},
+	"38,41": {
+		"terrainType": "LAND"
+	},
+	"38,42": {
+		"terrainType": "LAND"
+	},
+	"38,43": {
+		"terrainType": "LAND"
+	},
+	"38,44": {
+		"terrainType": "LAND"
+	},
+	"38,45": {
+		"terrainType": "LAND"
+	},
+	"38,46": {
+		"terrainType": "LAND"
+	},
+	"38,47": {
+		"terrainType": "LAND"
+	},
+	"38,48": {
+		"terrainType": "LAND"
+	},
+	"38,49": {
+		"terrainType": "LAND"
+	},
+	"38,50": {
+		"terrainType": "LAND"
+	},
+	"38,51": {
+		"terrainType": "LAND"
+	},
+	"38,52": {
+		"terrainType": "LAND"
+	},
+	"38,53": {
+		"terrainType": "LAND"
+	},
+	"38,54": {
+		"terrainType": "LAND"
+	},
+	"38,55": {
+		"terrainType": "LAND"
+	},
+	"38,56": {
+		"terrainType": "LAND"
+	},
+	"38,57": {
+		"terrainType": "LAND"
+	},
+	"38,58": {
+		"terrainType": "LAND"
+	},
+	"38,59": {
+		"terrainType": "LAND"
+	},
+	"38,60": {
+		"terrainType": "LAND"
+	},
+	"38,61": {
+		"terrainType": "LAND"
+	},
+	"38,62": {
+		"terrainType": "LAND"
+	},
+	"38,63": {
+		"terrainType": "LAND"
+	},
+	"39,0": {
+		"terrainType": "LAND"
+	},
+	"39,1": {
+		"terrainType": "LAND"
+	},
+	"39,2": {
+		"terrainType": "LAND"
+	},
+	"39,3": {
+		"terrainType": "LAND"
+	},
+	"39,4": {
+		"terrainType": "LAND"
+	},
+	"39,5": {
+		"terrainType": "LAND"
+	},
+	"39,6": {
+		"terrainType": "LAND"
+	},
+	"39,7": {
+		"terrainType": "LAND"
+	},
+	"39,8": {
+		"terrainType": "LAND"
+	},
+	"39,9": {
+		"terrainType": "LAND"
+	},
+	"39,10": {
+		"terrainType": "LAND"
+	},
+	"39,11": {
+		"terrainType": "LAND"
+	},
+	"39,12": {
+		"terrainType": "LAND"
+	},
+	"39,13": {
+		"terrainType": "LAND"
+	},
+	"39,14": {
+		"terrainType": "LAND"
+	},
+	"39,15": {
+		"terrainType": "LAND"
+	},
+	"39,16": {
+		"terrainType": "LAND"
+	},
+	"39,17": {
+		"terrainType": "LAND"
+	},
+	"39,18": {
+		"terrainType": "LAND"
+	},
+	"39,19": {
+		"terrainType": "LAND"
+	},
+	"39,20": {
+		"terrainType": "LAND"
+	},
+	"39,21": {
+		"terrainType": "LAND"
+	},
+	"39,22": {
+		"terrainType": "LAND"
+	},
+	"39,23": {
+		"terrainType": "LAND"
+	},
+	"39,24": {
+		"terrainType": "LAND"
+	},
+	"39,25": {
+		"terrainType": "LAND"
+	},
+	"39,26": {
+		"terrainType": "LAND"
+	},
+	"39,27": {
+		"terrainType": "LAND"
+	},
+	"39,28": {
+		"terrainType": "LAND"
+	},
+	"39,29": {
+		"terrainType": "LAND"
+	},
+	"39,30": {
+		"terrainType": "LAND"
+	},
+	"39,31": {
+		"terrainType": "LAND"
+	},
+	"39,32": {
+		"terrainType": "LAND"
+	},
+	"39,33": {
+		"terrainType": "LAND"
+	},
+	"39,34": {
+		"terrainType": "LAND"
+	},
+	"39,35": {
+		"terrainType": "LAND"
+	},
+	"39,36": {
+		"terrainType": "LAND"
+	},
+	"39,37": {
+		"terrainType": "LAND"
+	},
+	"39,38": {
+		"terrainType": "LAND"
+	},
+	"39,39": {
+		"terrainType": "LAND"
+	},
+	"39,40": {
+		"terrainType": "LAND"
+	},
+	"39,41": {
+		"terrainType": "LAND"
+	},
+	"39,42": {
+		"terrainType": "LAND"
+	},
+	"39,43": {
+		"terrainType": "LAND"
+	},
+	"39,44": {
+		"terrainType": "LAND"
+	},
+	"39,45": {
+		"terrainType": "LAND"
+	},
+	"39,46": {
+		"terrainType": "LAND"
+	},
+	"39,47": {
+		"terrainType": "LAND"
+	},
+	"39,48": {
+		"terrainType": "LAND"
+	},
+	"39,49": {
+		"terrainType": "LAND"
+	},
+	"39,50": {
+		"terrainType": "LAND"
+	},
+	"39,51": {
+		"terrainType": "LAND"
+	},
+	"39,52": {
+		"terrainType": "LAND"
+	},
+	"39,53": {
+		"terrainType": "LAND"
+	},
+	"39,54": {
+		"terrainType": "LAND"
+	},
+	"39,55": {
+		"terrainType": "LAND"
+	},
+	"39,56": {
+		"terrainType": "LAND"
+	},
+	"39,57": {
+		"terrainType": "LAND"
+	},
+	"39,58": {
+		"terrainType": "LAND"
+	},
+	"39,59": {
+		"terrainType": "LAND"
+	},
+	"39,60": {
+		"terrainType": "LAND"
+	},
+	"39,61": {
+		"terrainType": "LAND"
+	},
+	"39,62": {
+		"terrainType": "LAND"
+	},
+	"39,63": {
+		"terrainType": "LAND"
+	},
+	"40,0": {
+		"terrainType": "LAND"
+	},
+	"40,1": {
+		"terrainType": "LAND"
+	},
+	"40,2": {
+		"terrainType": "LAND"
+	},
+	"40,3": {
+		"terrainType": "LAND"
+	},
+	"40,4": {
+		"terrainType": "LAND"
+	},
+	"40,5": {
+		"terrainType": "LAND"
+	},
+	"40,6": {
+		"terrainType": "LAND"
+	},
+	"40,7": {
+		"terrainType": "LAND"
+	},
+	"40,8": {
+		"terrainType": "LAND"
+	},
+	"40,9": {
+		"terrainType": "LAND"
+	},
+	"40,10": {
+		"terrainType": "LAND"
+	},
+	"40,11": {
+		"terrainType": "LAND"
+	},
+	"40,12": {
+		"terrainType": "LAND"
+	},
+	"40,13": {
+		"terrainType": "LAND"
+	},
+	"40,14": {
+		"terrainType": "LAND"
+	},
+	"40,15": {
+		"terrainType": "LAND"
+	},
+	"40,16": {
+		"terrainType": "LAND"
+	},
+	"40,17": {
+		"terrainType": "LAND"
+	},
+	"40,18": {
+		"terrainType": "LAND"
+	},
+	"40,19": {
+		"terrainType": "LAND"
+	},
+	"40,20": {
+		"terrainType": "LAND"
+	},
+	"40,21": {
+		"terrainType": "LAND"
+	},
+	"40,22": {
+		"terrainType": "LAND"
+	},
+	"40,23": {
+		"terrainType": "LAND"
+	},
+	"40,24": {
+		"terrainType": "LAND"
+	},
+	"40,25": {
+		"terrainType": "LAND"
+	},
+	"40,26": {
+		"terrainType": "LAND"
+	},
+	"40,27": {
+		"terrainType": "LAND"
+	},
+	"40,28": {
+		"terrainType": "LAND"
+	},
+	"40,29": {
+		"terrainType": "LAND"
+	},
+	"40,30": {
+		"terrainType": "LAND"
+	},
+	"40,31": {
+		"terrainType": "LAND"
+	},
+	"40,32": {
+		"terrainType": "LAND"
+	},
+	"40,33": {
+		"terrainType": "LAND"
+	},
+	"40,34": {
+		"terrainType": "LAND"
+	},
+	"40,35": {
+		"terrainType": "LAND"
+	},
+	"40,36": {
+		"terrainType": "LAND"
+	},
+	"40,37": {
+		"terrainType": "LAND"
+	},
+	"40,38": {
+		"terrainType": "LAND"
+	},
+	"40,39": {
+		"terrainType": "LAND"
+	},
+	"40,40": {
+		"terrainType": "LAND"
+	},
+	"40,41": {
+		"terrainType": "LAND"
+	},
+	"40,42": {
+		"terrainType": "LAND"
+	},
+	"40,43": {
+		"terrainType": "LAND"
+	},
+	"40,44": {
+		"terrainType": "LAND"
+	},
+	"40,45": {
+		"terrainType": "LAND"
+	},
+	"40,46": {
+		"terrainType": "LAND"
+	},
+	"40,47": {
+		"terrainType": "LAND"
+	},
+	"40,48": {
+		"terrainType": "LAND"
+	},
+	"40,49": {
+		"terrainType": "LAND"
+	},
+	"40,50": {
+		"terrainType": "LAND"
+	},
+	"40,51": {
+		"terrainType": "LAND"
+	},
+	"40,52": {
+		"terrainType": "LAND"
+	},
+	"40,53": {
+		"terrainType": "LAND"
+	},
+	"40,54": {
+		"terrainType": "LAND"
+	},
+	"40,55": {
+		"terrainType": "LAND"
+	},
+	"40,56": {
+		"terrainType": "LAND"
+	},
+	"40,57": {
+		"terrainType": "LAND"
+	},
+	"40,58": {
+		"terrainType": "LAND"
+	},
+	"40,59": {
+		"terrainType": "LAND"
+	},
+	"40,60": {
+		"terrainType": "LAND"
+	},
+	"40,61": {
+		"terrainType": "LAND"
+	},
+	"40,62": {
+		"terrainType": "LAND"
+	},
+	"40,63": {
+		"terrainType": "LAND"
+	},
+	"41,0": {
+		"terrainType": "LAND"
+	},
+	"41,1": {
+		"terrainType": "LAND"
+	},
+	"41,2": {
+		"terrainType": "LAND"
+	},
+	"41,3": {
+		"terrainType": "LAND"
+	},
+	"41,4": {
+		"terrainType": "LAND"
+	},
+	"41,5": {
+		"terrainType": "LAND"
+	},
+	"41,6": {
+		"terrainType": "LAND"
+	},
+	"41,7": {
+		"terrainType": "LAND"
+	},
+	"41,8": {
+		"terrainType": "LAND"
+	},
+	"41,9": {
+		"terrainType": "LAND"
+	},
+	"41,10": {
+		"terrainType": "LAND"
+	},
+	"41,11": {
+		"terrainType": "LAND"
+	},
+	"41,12": {
+		"terrainType": "LAND"
+	},
+	"41,13": {
+		"terrainType": "LAND"
+	},
+	"41,14": {
+		"terrainType": "LAND"
+	},
+	"41,15": {
+		"terrainType": "LAND"
+	},
+	"41,16": {
+		"terrainType": "LAND"
+	},
+	"41,17": {
+		"terrainType": "LAND"
+	},
+	"41,18": {
+		"terrainType": "LAND"
+	},
+	"41,19": {
+		"terrainType": "LAND"
+	},
+	"41,20": {
+		"terrainType": "LAND"
+	},
+	"41,21": {
+		"terrainType": "LAND"
+	},
+	"41,22": {
+		"terrainType": "LAND"
+	},
+	"41,23": {
+		"terrainType": "LAND"
+	},
+	"41,24": {
+		"terrainType": "LAND"
+	},
+	"41,25": {
+		"terrainType": "LAND"
+	},
+	"41,26": {
+		"terrainType": "LAND"
+	},
+	"41,27": {
+		"terrainType": "LAND"
+	},
+	"41,28": {
+		"terrainType": "LAND"
+	},
+	"41,29": {
+		"terrainType": "LAND"
+	},
+	"41,30": {
+		"terrainType": "LAND"
+	},
+	"41,31": {
+		"terrainType": "LAND"
+	},
+	"41,32": {
+		"terrainType": "LAND"
+	},
+	"41,33": {
+		"terrainType": "LAND"
+	},
+	"41,34": {
+		"terrainType": "LAND"
+	},
+	"41,35": {
+		"terrainType": "LAND"
+	},
+	"41,36": {
+		"terrainType": "LAND"
+	},
+	"41,37": {
+		"terrainType": "LAND"
+	},
+	"41,38": {
+		"terrainType": "LAND"
+	},
+	"41,39": {
+		"terrainType": "LAND"
+	},
+	"41,40": {
+		"terrainType": "LAND"
+	},
+	"41,41": {
+		"terrainType": "LAND"
+	},
+	"41,42": {
+		"terrainType": "LAND"
+	},
+	"41,43": {
+		"terrainType": "LAND"
+	},
+	"41,44": {
+		"terrainType": "LAND"
+	},
+	"41,45": {
+		"terrainType": "LAND"
+	},
+	"41,46": {
+		"terrainType": "LAND"
+	},
+	"41,47": {
+		"terrainType": "LAND"
+	},
+	"41,48": {
+		"terrainType": "LAND"
+	},
+	"41,49": {
+		"terrainType": "LAND"
+	},
+	"41,50": {
+		"terrainType": "LAND"
+	},
+	"41,51": {
+		"terrainType": "LAND"
+	},
+	"41,52": {
+		"terrainType": "LAND"
+	},
+	"41,53": {
+		"terrainType": "LAND"
+	},
+	"41,54": {
+		"terrainType": "LAND"
+	},
+	"41,55": {
+		"terrainType": "LAND"
+	},
+	"41,56": {
+		"terrainType": "LAND"
+	},
+	"41,57": {
+		"terrainType": "LAND"
+	},
+	"41,58": {
+		"terrainType": "LAND"
+	},
+	"41,59": {
+		"terrainType": "LAND"
+	},
+	"41,60": {
+		"terrainType": "LAND"
+	},
+	"41,61": {
+		"terrainType": "LAND"
+	},
+	"41,62": {
+		"terrainType": "LAND"
+	},
+	"41,63": {
+		"terrainType": "LAND"
+	},
+	"42,0": {
+		"terrainType": "LAND"
+	},
+	"42,1": {
+		"terrainType": "LAND"
+	},
+	"42,2": {
+		"terrainType": "LAND"
+	},
+	"42,3": {
+		"terrainType": "LAND"
+	},
+	"42,4": {
+		"terrainType": "LAND"
+	},
+	"42,5": {
+		"terrainType": "LAND"
+	},
+	"42,6": {
+		"terrainType": "LAND"
+	},
+	"42,7": {
+		"terrainType": "LAND"
+	},
+	"42,8": {
+		"terrainType": "LAND"
+	},
+	"42,9": {
+		"terrainType": "LAND"
+	},
+	"42,10": {
+		"terrainType": "LAND"
+	},
+	"42,11": {
+		"terrainType": "LAND"
+	},
+	"42,12": {
+		"terrainType": "LAND"
+	},
+	"42,13": {
+		"terrainType": "LAND"
+	},
+	"42,14": {
+		"terrainType": "LAND"
+	},
+	"42,15": {
+		"terrainType": "LAND"
+	},
+	"42,16": {
+		"terrainType": "LAND"
+	},
+	"42,17": {
+		"terrainType": "LAND"
+	},
+	"42,18": {
+		"terrainType": "LAND"
+	},
+	"42,19": {
+		"terrainType": "LAND"
+	},
+	"42,20": {
+		"terrainType": "LAND"
+	},
+	"42,21": {
+		"terrainType": "LAND"
+	},
+	"42,22": {
+		"terrainType": "LAND"
+	},
+	"42,23": {
+		"terrainType": "LAND"
+	},
+	"42,24": {
+		"terrainType": "LAND"
+	},
+	"42,25": {
+		"terrainType": "LAND"
+	},
+	"42,26": {
+		"terrainType": "LAND"
+	},
+	"42,27": {
+		"terrainType": "LAND"
+	},
+	"42,28": {
+		"terrainType": "LAND"
+	},
+	"42,29": {
+		"terrainType": "LAND"
+	},
+	"42,30": {
+		"terrainType": "LAND"
+	},
+	"42,31": {
+		"terrainType": "LAND"
+	},
+	"42,32": {
+		"terrainType": "LAND"
+	},
+	"42,33": {
+		"terrainType": "LAND"
+	},
+	"42,34": {
+		"terrainType": "LAND"
+	},
+	"42,35": {
+		"terrainType": "LAND"
+	},
+	"42,36": {
+		"terrainType": "LAND"
+	},
+	"42,37": {
+		"terrainType": "LAND"
+	},
+	"42,38": {
+		"terrainType": "LAND"
+	},
+	"42,39": {
+		"terrainType": "LAND"
+	},
+	"42,40": {
+		"terrainType": "LAND"
+	},
+	"42,41": {
+		"terrainType": "LAND"
+	},
+	"42,42": {
+		"terrainType": "LAND"
+	},
+	"42,43": {
+		"terrainType": "LAND"
+	},
+	"42,44": {
+		"terrainType": "LAND"
+	},
+	"42,45": {
+		"terrainType": "LAND"
+	},
+	"42,46": {
+		"terrainType": "LAND"
+	},
+	"42,47": {
+		"terrainType": "LAND"
+	},
+	"42,48": {
+		"terrainType": "LAND"
+	},
+	"42,49": {
+		"terrainType": "LAND"
+	},
+	"42,50": {
+		"terrainType": "LAND"
+	},
+	"42,51": {
+		"terrainType": "LAND"
+	},
+	"42,52": {
+		"terrainType": "LAND"
+	},
+	"42,53": {
+		"terrainType": "LAND"
+	},
+	"42,54": {
+		"terrainType": "LAND"
+	},
+	"42,55": {
+		"terrainType": "LAND"
+	},
+	"42,56": {
+		"terrainType": "LAND"
+	},
+	"42,57": {
+		"terrainType": "LAND"
+	},
+	"42,58": {
+		"terrainType": "LAND"
+	},
+	"42,59": {
+		"terrainType": "LAND"
+	},
+	"42,60": {
+		"terrainType": "LAND"
+	},
+	"42,61": {
+		"terrainType": "LAND"
+	},
+	"42,62": {
+		"terrainType": "LAND"
+	},
+	"42,63": {
+		"terrainType": "LAND"
+	},
+	"43,0": {
+		"terrainType": "LAND"
+	},
+	"43,1": {
+		"terrainType": "LAND"
+	},
+	"43,2": {
+		"terrainType": "LAND"
+	},
+	"43,3": {
+		"terrainType": "LAND"
+	},
+	"43,4": {
+		"terrainType": "LAND"
+	},
+	"43,5": {
+		"terrainType": "LAND"
+	},
+	"43,6": {
+		"terrainType": "LAND"
+	},
+	"43,7": {
+		"terrainType": "LAND"
+	},
+	"43,8": {
+		"terrainType": "LAND"
+	},
+	"43,9": {
+		"terrainType": "LAND"
+	},
+	"43,10": {
+		"terrainType": "LAND"
+	},
+	"43,11": {
+		"terrainType": "LAND"
+	},
+	"43,12": {
+		"terrainType": "LAND"
+	},
+	"43,13": {
+		"terrainType": "LAND"
+	},
+	"43,14": {
+		"terrainType": "LAND"
+	},
+	"43,15": {
+		"terrainType": "LAND"
+	},
+	"43,16": {
+		"terrainType": "LAND"
+	},
+	"43,17": {
+		"terrainType": "LAND"
+	},
+	"43,18": {
+		"terrainType": "LAND"
+	},
+	"43,19": {
+		"terrainType": "LAND"
+	},
+	"43,20": {
+		"terrainType": "LAND"
+	},
+	"43,21": {
+		"terrainType": "LAND"
+	},
+	"43,22": {
+		"terrainType": "LAND"
+	},
+	"43,23": {
+		"terrainType": "LAND"
+	},
+	"43,24": {
+		"terrainType": "LAND"
+	},
+	"43,25": {
+		"terrainType": "LAND"
+	},
+	"43,26": {
+		"terrainType": "LAND"
+	},
+	"43,27": {
+		"terrainType": "LAND"
+	},
+	"43,28": {
+		"terrainType": "LAND"
+	},
+	"43,29": {
+		"terrainType": "LAND"
+	},
+	"43,30": {
+		"terrainType": "LAND"
+	},
+	"43,31": {
+		"terrainType": "LAND"
+	},
+	"43,32": {
+		"terrainType": "LAND"
+	},
+	"43,33": {
+		"terrainType": "LAND"
+	},
+	"43,34": {
+		"terrainType": "LAND"
+	},
+	"43,35": {
+		"terrainType": "LAND"
+	},
+	"43,36": {
+		"terrainType": "LAND"
+	},
+	"43,37": {
+		"terrainType": "LAND"
+	},
+	"43,38": {
+		"terrainType": "LAND"
+	},
+	"43,39": {
+		"terrainType": "LAND"
+	},
+	"43,40": {
+		"terrainType": "LAND"
+	},
+	"43,41": {
+		"terrainType": "LAND"
+	},
+	"43,42": {
+		"terrainType": "LAND"
+	},
+	"43,43": {
+		"terrainType": "LAND"
+	},
+	"43,44": {
+		"terrainType": "LAND"
+	},
+	"43,45": {
+		"terrainType": "LAND"
+	},
+	"43,46": {
+		"terrainType": "LAND"
+	},
+	"43,47": {
+		"terrainType": "LAND"
+	},
+	"43,48": {
+		"terrainType": "LAND"
+	},
+	"43,49": {
+		"terrainType": "LAND"
+	},
+	"43,50": {
+		"terrainType": "LAND"
+	},
+	"43,51": {
+		"terrainType": "LAND"
+	},
+	"43,52": {
+		"terrainType": "LAND"
+	},
+	"43,53": {
+		"terrainType": "LAND"
+	},
+	"43,54": {
+		"terrainType": "LAND"
+	},
+	"43,55": {
+		"terrainType": "LAND"
+	},
+	"43,56": {
+		"terrainType": "LAND"
+	},
+	"43,57": {
+		"terrainType": "LAND"
+	},
+	"43,58": {
+		"terrainType": "LAND"
+	},
+	"43,59": {
+		"terrainType": "LAND"
+	},
+	"43,60": {
+		"terrainType": "LAND"
+	},
+	"43,61": {
+		"terrainType": "LAND"
+	},
+	"43,62": {
+		"terrainType": "LAND"
+	},
+	"43,63": {
+		"terrainType": "LAND"
+	},
+	"44,0": {
+		"terrainType": "LAND"
+	},
+	"44,1": {
+		"terrainType": "LAND"
+	},
+	"44,2": {
+		"terrainType": "LAND"
+	},
+	"44,3": {
+		"terrainType": "LAND"
+	},
+	"44,4": {
+		"terrainType": "LAND"
+	},
+	"44,5": {
+		"terrainType": "LAND"
+	},
+	"44,6": {
+		"terrainType": "LAND"
+	},
+	"44,7": {
+		"terrainType": "LAND"
+	},
+	"44,8": {
+		"terrainType": "LAND"
+	},
+	"44,9": {
+		"terrainType": "LAND"
+	},
+	"44,10": {
+		"terrainType": "LAND"
+	},
+	"44,11": {
+		"terrainType": "LAND"
+	},
+	"44,12": {
+		"terrainType": "LAND"
+	},
+	"44,13": {
+		"terrainType": "LAND"
+	},
+	"44,14": {
+		"terrainType": "LAND"
+	},
+	"44,15": {
+		"terrainType": "LAND"
+	},
+	"44,16": {
+		"terrainType": "LAND"
+	},
+	"44,17": {
+		"terrainType": "LAND"
+	},
+	"44,18": {
+		"terrainType": "LAND"
+	},
+	"44,19": {
+		"terrainType": "LAND"
+	},
+	"44,20": {
+		"terrainType": "LAND"
+	},
+	"44,21": {
+		"terrainType": "LAND"
+	},
+	"44,22": {
+		"terrainType": "LAND"
+	},
+	"44,23": {
+		"terrainType": "LAND"
+	},
+	"44,24": {
+		"terrainType": "LAND"
+	},
+	"44,25": {
+		"terrainType": "LAND"
+	},
+	"44,26": {
+		"terrainType": "LAND"
+	},
+	"44,27": {
+		"terrainType": "LAND"
+	},
+	"44,28": {
+		"terrainType": "LAND"
+	},
+	"44,29": {
+		"terrainType": "LAND"
+	},
+	"44,30": {
+		"terrainType": "LAND"
+	},
+	"44,31": {
+		"terrainType": "LAND"
+	},
+	"44,32": {
+		"terrainType": "LAND"
+	},
+	"44,33": {
+		"terrainType": "LAND"
+	},
+	"44,34": {
+		"terrainType": "LAND"
+	},
+	"44,35": {
+		"terrainType": "LAND"
+	},
+	"44,36": {
+		"terrainType": "LAND"
+	},
+	"44,37": {
+		"terrainType": "LAND"
+	},
+	"44,38": {
+		"terrainType": "LAND"
+	},
+	"44,39": {
+		"terrainType": "LAND"
+	},
+	"44,40": {
+		"terrainType": "LAND"
+	},
+	"44,41": {
+		"terrainType": "LAND"
+	},
+	"44,42": {
+		"terrainType": "LAND"
+	},
+	"44,43": {
+		"terrainType": "LAND"
+	},
+	"44,44": {
+		"terrainType": "LAND"
+	},
+	"44,45": {
+		"terrainType": "LAND"
+	},
+	"44,46": {
+		"terrainType": "LAND"
+	},
+	"44,47": {
+		"terrainType": "LAND"
+	},
+	"44,48": {
+		"terrainType": "LAND"
+	},
+	"44,49": {
+		"terrainType": "LAND"
+	},
+	"44,50": {
+		"terrainType": "LAND"
+	},
+	"44,51": {
+		"terrainType": "LAND"
+	},
+	"44,52": {
+		"terrainType": "LAND"
+	},
+	"44,53": {
+		"terrainType": "LAND"
+	},
+	"44,54": {
+		"terrainType": "LAND"
+	},
+	"44,55": {
+		"terrainType": "LAND"
+	},
+	"44,56": {
+		"terrainType": "LAND"
+	},
+	"44,57": {
+		"terrainType": "LAND"
+	},
+	"44,58": {
+		"terrainType": "LAND"
+	},
+	"44,59": {
+		"terrainType": "LAND"
+	},
+	"44,60": {
+		"terrainType": "LAND"
+	},
+	"44,61": {
+		"terrainType": "LAND"
+	},
+	"44,62": {
+		"terrainType": "LAND"
+	},
+	"44,63": {
+		"terrainType": "LAND"
+	},
+	"45,0": {
+		"terrainType": "LAND"
+	},
+	"45,1": {
+		"terrainType": "LAND"
+	},
+	"45,2": {
+		"terrainType": "LAND"
+	},
+	"45,3": {
+		"terrainType": "LAND"
+	},
+	"45,4": {
+		"terrainType": "LAND"
+	},
+	"45,5": {
+		"terrainType": "LAND"
+	},
+	"45,6": {
+		"terrainType": "LAND"
+	},
+	"45,7": {
+		"terrainType": "LAND"
+	},
+	"45,8": {
+		"terrainType": "LAND"
+	},
+	"45,9": {
+		"terrainType": "LAND"
+	},
+	"45,10": {
+		"terrainType": "LAND"
+	},
+	"45,11": {
+		"terrainType": "LAND"
+	},
+	"45,12": {
+		"terrainType": "LAND"
+	},
+	"45,13": {
+		"terrainType": "LAND"
+	},
+	"45,14": {
+		"terrainType": "LAND"
+	},
+	"45,15": {
+		"terrainType": "LAND"
+	},
+	"45,16": {
+		"terrainType": "LAND"
+	},
+	"45,17": {
+		"terrainType": "LAND"
+	},
+	"45,18": {
+		"terrainType": "LAND"
+	},
+	"45,19": {
+		"terrainType": "LAND"
+	},
+	"45,20": {
+		"terrainType": "LAND"
+	},
+	"45,21": {
+		"terrainType": "LAND"
+	},
+	"45,22": {
+		"terrainType": "LAND"
+	},
+	"45,23": {
+		"terrainType": "LAND"
+	},
+	"45,24": {
+		"terrainType": "LAND"
+	},
+	"45,25": {
+		"terrainType": "LAND"
+	},
+	"45,26": {
+		"terrainType": "LAND"
+	},
+	"45,27": {
+		"terrainType": "LAND"
+	},
+	"45,28": {
+		"terrainType": "LAND"
+	},
+	"45,29": {
+		"terrainType": "LAND"
+	},
+	"45,30": {
+		"terrainType": "LAND"
+	},
+	"45,31": {
+		"terrainType": "LAND"
+	},
+	"45,32": {
+		"terrainType": "LAND"
+	},
+	"45,33": {
+		"terrainType": "LAND"
+	},
+	"45,34": {
+		"terrainType": "LAND"
+	},
+	"45,35": {
+		"terrainType": "LAND"
+	},
+	"45,36": {
+		"terrainType": "LAND"
+	},
+	"45,37": {
+		"terrainType": "LAND"
+	},
+	"45,38": {
+		"terrainType": "LAND"
+	},
+	"45,39": {
+		"terrainType": "LAND"
+	},
+	"45,40": {
+		"terrainType": "LAND"
+	},
+	"45,41": {
+		"terrainType": "LAND"
+	},
+	"45,42": {
+		"terrainType": "LAND"
+	},
+	"45,43": {
+		"terrainType": "LAND"
+	},
+	"45,44": {
+		"terrainType": "LAND"
+	},
+	"45,45": {
+		"terrainType": "LAND"
+	},
+	"45,46": {
+		"terrainType": "LAND"
+	},
+	"45,47": {
+		"terrainType": "LAND"
+	},
+	"45,48": {
+		"terrainType": "LAND"
+	},
+	"45,49": {
+		"terrainType": "LAND"
+	},
+	"45,50": {
+		"terrainType": "LAND"
+	},
+	"45,51": {
+		"terrainType": "LAND"
+	},
+	"45,52": {
+		"terrainType": "LAND"
+	},
+	"45,53": {
+		"terrainType": "LAND"
+	},
+	"45,54": {
+		"terrainType": "LAND"
+	},
+	"45,55": {
+		"terrainType": "LAND"
+	},
+	"45,56": {
+		"terrainType": "LAND"
+	},
+	"45,57": {
+		"terrainType": "LAND"
+	},
+	"45,58": {
+		"terrainType": "LAND"
+	},
+	"45,59": {
+		"terrainType": "LAND"
+	},
+	"45,60": {
+		"terrainType": "LAND"
+	},
+	"45,61": {
+		"terrainType": "LAND"
+	},
+	"45,62": {
+		"terrainType": "LAND"
+	},
+	"45,63": {
+		"terrainType": "LAND"
+	},
+	"46,0": {
+		"terrainType": "LAND"
+	},
+	"46,1": {
+		"terrainType": "LAND"
+	},
+	"46,2": {
+		"terrainType": "LAND"
+	},
+	"46,3": {
+		"terrainType": "LAND"
+	},
+	"46,4": {
+		"terrainType": "LAND"
+	},
+	"46,5": {
+		"terrainType": "LAND"
+	},
+	"46,6": {
+		"terrainType": "LAND"
+	},
+	"46,7": {
+		"terrainType": "LAND"
+	},
+	"46,8": {
+		"terrainType": "LAND"
+	},
+	"46,9": {
+		"terrainType": "LAND"
+	},
+	"46,10": {
+		"terrainType": "LAND"
+	},
+	"46,11": {
+		"terrainType": "LAND"
+	},
+	"46,12": {
+		"terrainType": "LAND"
+	},
+	"46,13": {
+		"terrainType": "LAND"
+	},
+	"46,14": {
+		"terrainType": "LAND"
+	},
+	"46,15": {
+		"terrainType": "LAND"
+	},
+	"46,16": {
+		"terrainType": "LAND"
+	},
+	"46,17": {
+		"terrainType": "LAND"
+	},
+	"46,18": {
+		"terrainType": "LAND"
+	},
+	"46,19": {
+		"terrainType": "LAND"
+	},
+	"46,20": {
+		"terrainType": "LAND"
+	},
+	"46,21": {
+		"terrainType": "LAND"
+	},
+	"46,22": {
+		"terrainType": "LAND"
+	},
+	"46,23": {
+		"terrainType": "LAND"
+	},
+	"46,24": {
+		"terrainType": "LAND"
+	},
+	"46,25": {
+		"terrainType": "LAND"
+	},
+	"46,26": {
+		"terrainType": "LAND"
+	},
+	"46,27": {
+		"terrainType": "LAND"
+	},
+	"46,28": {
+		"terrainType": "LAND"
+	},
+	"46,29": {
+		"terrainType": "LAND"
+	},
+	"46,30": {
+		"terrainType": "LAND"
+	},
+	"46,31": {
+		"terrainType": "LAND"
+	},
+	"46,32": {
+		"terrainType": "LAND"
+	},
+	"46,33": {
+		"terrainType": "LAND"
+	},
+	"46,34": {
+		"terrainType": "LAND"
+	},
+	"46,35": {
+		"terrainType": "LAND"
+	},
+	"46,36": {
+		"terrainType": "LAND"
+	},
+	"46,37": {
+		"terrainType": "LAND"
+	},
+	"46,38": {
+		"terrainType": "LAND"
+	},
+	"46,39": {
+		"terrainType": "LAND"
+	},
+	"46,40": {
+		"terrainType": "LAND"
+	},
+	"46,41": {
+		"terrainType": "LAND"
+	},
+	"46,42": {
+		"terrainType": "LAND"
+	},
+	"46,43": {
+		"terrainType": "LAND"
+	},
+	"46,44": {
+		"terrainType": "LAND"
+	},
+	"46,45": {
+		"terrainType": "LAND"
+	},
+	"46,46": {
+		"terrainType": "LAND"
+	},
+	"46,47": {
+		"terrainType": "LAND"
+	},
+	"46,48": {
+		"terrainType": "LAND"
+	},
+	"46,49": {
+		"terrainType": "LAND"
+	},
+	"46,50": {
+		"terrainType": "LAND"
+	},
+	"46,51": {
+		"terrainType": "LAND"
+	},
+	"46,52": {
+		"terrainType": "LAND"
+	},
+	"46,53": {
+		"terrainType": "LAND"
+	},
+	"46,54": {
+		"terrainType": "LAND"
+	},
+	"46,55": {
+		"terrainType": "LAND"
+	},
+	"46,56": {
+		"terrainType": "LAND"
+	},
+	"46,57": {
+		"terrainType": "LAND"
+	},
+	"46,58": {
+		"terrainType": "LAND"
+	},
+	"46,59": {
+		"terrainType": "LAND"
+	},
+	"46,60": {
+		"terrainType": "LAND"
+	},
+	"46,61": {
+		"terrainType": "LAND"
+	},
+	"46,62": {
+		"terrainType": "LAND"
+	},
+	"46,63": {
+		"terrainType": "LAND"
+	},
+	"47,0": {
+		"terrainType": "LAND"
+	},
+	"47,1": {
+		"terrainType": "LAND"
+	},
+	"47,2": {
+		"terrainType": "LAND"
+	},
+	"47,3": {
+		"terrainType": "LAND"
+	},
+	"47,4": {
+		"terrainType": "LAND"
+	},
+	"47,5": {
+		"terrainType": "LAND"
+	},
+	"47,6": {
+		"terrainType": "LAND"
+	},
+	"47,7": {
+		"terrainType": "LAND"
+	},
+	"47,8": {
+		"terrainType": "LAND"
+	},
+	"47,9": {
+		"terrainType": "LAND"
+	},
+	"47,10": {
+		"terrainType": "LAND"
+	},
+	"47,11": {
+		"terrainType": "LAND"
+	},
+	"47,12": {
+		"terrainType": "LAND"
+	},
+	"47,13": {
+		"terrainType": "LAND"
+	},
+	"47,14": {
+		"terrainType": "LAND"
+	},
+	"47,15": {
+		"terrainType": "LAND"
+	},
+	"47,16": {
+		"terrainType": "LAND"
+	},
+	"47,17": {
+		"terrainType": "LAND"
+	},
+	"47,18": {
+		"terrainType": "LAND"
+	},
+	"47,19": {
+		"terrainType": "LAND"
+	},
+	"47,20": {
+		"terrainType": "LAND"
+	},
+	"47,21": {
+		"terrainType": "LAND"
+	},
+	"47,22": {
+		"terrainType": "LAND"
+	},
+	"47,23": {
+		"terrainType": "LAND"
+	},
+	"47,24": {
+		"terrainType": "LAND"
+	},
+	"47,25": {
+		"terrainType": "LAND"
+	},
+	"47,26": {
+		"terrainType": "LAND"
+	},
+	"47,27": {
+		"terrainType": "LAND"
+	},
+	"47,28": {
+		"terrainType": "LAND"
+	},
+	"47,29": {
+		"terrainType": "LAND"
+	},
+	"47,30": {
+		"terrainType": "LAND"
+	},
+	"47,31": {
+		"terrainType": "LAND"
+	},
+	"47,32": {
+		"terrainType": "LAND"
+	},
+	"47,33": {
+		"terrainType": "LAND"
+	},
+	"47,34": {
+		"terrainType": "LAND"
+	},
+	"47,35": {
+		"terrainType": "LAND"
+	},
+	"47,36": {
+		"terrainType": "LAND"
+	},
+	"47,37": {
+		"terrainType": "LAND"
+	},
+	"47,38": {
+		"terrainType": "LAND"
+	},
+	"47,39": {
+		"terrainType": "LAND"
+	},
+	"47,40": {
+		"terrainType": "LAND"
+	},
+	"47,41": {
+		"terrainType": "LAND"
+	},
+	"47,42": {
+		"terrainType": "LAND"
+	},
+	"47,43": {
+		"terrainType": "LAND"
+	},
+	"47,44": {
+		"terrainType": "LAND"
+	},
+	"47,45": {
+		"terrainType": "LAND"
+	},
+	"47,46": {
+		"terrainType": "LAND"
+	},
+	"47,47": {
+		"terrainType": "LAND"
+	},
+	"47,48": {
+		"terrainType": "LAND"
+	},
+	"47,49": {
+		"terrainType": "LAND"
+	},
+	"47,50": {
+		"terrainType": "LAND"
+	},
+	"47,51": {
+		"terrainType": "LAND"
+	},
+	"47,52": {
+		"terrainType": "LAND"
+	},
+	"47,53": {
+		"terrainType": "LAND"
+	},
+	"47,54": {
+		"terrainType": "LAND"
+	},
+	"47,55": {
+		"terrainType": "LAND"
+	},
+	"47,56": {
+		"terrainType": "LAND"
+	},
+	"47,57": {
+		"terrainType": "LAND"
+	},
+	"47,58": {
+		"terrainType": "LAND"
+	},
+	"47,59": {
+		"terrainType": "LAND"
+	},
+	"47,60": {
+		"terrainType": "LAND"
+	},
+	"47,61": {
+		"terrainType": "LAND"
+	},
+	"47,62": {
+		"terrainType": "LAND"
+	},
+	"47,63": {
+		"terrainType": "LAND"
+	},
+	"48,0": {
+		"terrainType": "LAND"
+	},
+	"48,1": {
+		"terrainType": "LAND"
+	},
+	"48,2": {
+		"terrainType": "LAND"
+	},
+	"48,3": {
+		"terrainType": "LAND"
+	},
+	"48,4": {
+		"terrainType": "LAND"
+	},
+	"48,5": {
+		"terrainType": "LAND"
+	},
+	"48,6": {
+		"terrainType": "LAND"
+	},
+	"48,7": {
+		"terrainType": "LAND"
+	},
+	"48,8": {
+		"terrainType": "LAND"
+	},
+	"48,9": {
+		"terrainType": "LAND"
+	},
+	"48,10": {
+		"terrainType": "LAND"
+	},
+	"48,11": {
+		"terrainType": "LAND"
+	},
+	"48,12": {
+		"terrainType": "LAND"
+	},
+	"48,13": {
+		"terrainType": "LAND"
+	},
+	"48,14": {
+		"terrainType": "LAND"
+	},
+	"48,15": {
+		"terrainType": "LAND"
+	},
+	"48,16": {
+		"terrainType": "LAND"
+	},
+	"48,17": {
+		"terrainType": "LAND"
+	},
+	"48,18": {
+		"terrainType": "LAND"
+	},
+	"48,19": {
+		"terrainType": "LAND"
+	},
+	"48,20": {
+		"terrainType": "LAND"
+	},
+	"48,21": {
+		"terrainType": "LAND"
+	},
+	"48,22": {
+		"terrainType": "LAND"
+	},
+	"48,23": {
+		"terrainType": "LAND"
+	},
+	"48,24": {
+		"terrainType": "LAND"
+	},
+	"48,25": {
+		"terrainType": "LAND"
+	},
+	"48,26": {
+		"terrainType": "LAND"
+	},
+	"48,27": {
+		"terrainType": "LAND"
+	},
+	"48,28": {
+		"terrainType": "LAND"
+	},
+	"48,29": {
+		"terrainType": "LAND"
+	},
+	"48,30": {
+		"terrainType": "LAND"
+	},
+	"48,31": {
+		"terrainType": "LAND"
+	},
+	"48,32": {
+		"terrainType": "LAND"
+	},
+	"48,33": {
+		"terrainType": "LAND"
+	},
+	"48,34": {
+		"terrainType": "LAND"
+	},
+	"48,35": {
+		"terrainType": "LAND"
+	},
+	"48,36": {
+		"terrainType": "LAND"
+	},
+	"48,37": {
+		"terrainType": "LAND"
+	},
+	"48,38": {
+		"terrainType": "LAND"
+	},
+	"48,39": {
+		"terrainType": "LAND"
+	},
+	"48,40": {
+		"terrainType": "LAND"
+	},
+	"48,41": {
+		"terrainType": "LAND"
+	},
+	"48,42": {
+		"terrainType": "LAND"
+	},
+	"48,43": {
+		"terrainType": "LAND"
+	},
+	"48,44": {
+		"terrainType": "LAND"
+	},
+	"48,45": {
+		"terrainType": "LAND"
+	},
+	"48,46": {
+		"terrainType": "LAND"
+	},
+	"48,47": {
+		"terrainType": "LAND"
+	},
+	"48,48": {
+		"terrainType": "LAND"
+	},
+	"48,49": {
+		"terrainType": "LAND"
+	},
+	"48,50": {
+		"terrainType": "LAND"
+	},
+	"48,51": {
+		"terrainType": "LAND"
+	},
+	"48,52": {
+		"terrainType": "LAND"
+	},
+	"48,53": {
+		"terrainType": "LAND"
+	},
+	"48,54": {
+		"terrainType": "LAND"
+	},
+	"48,55": {
+		"terrainType": "LAND"
+	},
+	"48,56": {
+		"terrainType": "LAND"
+	},
+	"48,57": {
+		"terrainType": "LAND"
+	},
+	"48,58": {
+		"terrainType": "LAND"
+	},
+	"48,59": {
+		"terrainType": "LAND"
+	},
+	"48,60": {
+		"terrainType": "LAND"
+	},
+	"48,61": {
+		"terrainType": "LAND"
+	},
+	"48,62": {
+		"terrainType": "LAND"
+	},
+	"48,63": {
+		"terrainType": "LAND"
+	},
+	"49,0": {
+		"terrainType": "LAND"
+	},
+	"49,1": {
+		"terrainType": "LAND"
+	},
+	"49,2": {
+		"terrainType": "LAND"
+	},
+	"49,3": {
+		"terrainType": "LAND"
+	},
+	"49,4": {
+		"terrainType": "LAND"
+	},
+	"49,5": {
+		"terrainType": "LAND"
+	},
+	"49,6": {
+		"terrainType": "LAND"
+	},
+	"49,7": {
+		"terrainType": "LAND"
+	},
+	"49,8": {
+		"terrainType": "LAND"
+	},
+	"49,9": {
+		"terrainType": "LAND"
+	},
+	"49,10": {
+		"terrainType": "LAND"
+	},
+	"49,11": {
+		"terrainType": "LAND"
+	},
+	"49,12": {
+		"terrainType": "LAND"
+	},
+	"49,13": {
+		"terrainType": "LAND"
+	},
+	"49,14": {
+		"terrainType": "LAND"
+	},
+	"49,15": {
+		"terrainType": "LAND"
+	},
+	"49,16": {
+		"terrainType": "LAND"
+	},
+	"49,17": {
+		"terrainType": "LAND"
+	},
+	"49,18": {
+		"terrainType": "LAND"
+	},
+	"49,19": {
+		"terrainType": "LAND"
+	},
+	"49,20": {
+		"terrainType": "LAND"
+	},
+	"49,21": {
+		"terrainType": "LAND"
+	},
+	"49,22": {
+		"terrainType": "LAND"
+	},
+	"49,23": {
+		"terrainType": "LAND"
+	},
+	"49,24": {
+		"terrainType": "LAND"
+	},
+	"49,25": {
+		"terrainType": "LAND"
+	},
+	"49,26": {
+		"terrainType": "LAND"
+	},
+	"49,27": {
+		"terrainType": "LAND"
+	},
+	"49,28": {
+		"terrainType": "LAND"
+	},
+	"49,29": {
+		"terrainType": "LAND"
+	},
+	"49,30": {
+		"terrainType": "LAND"
+	},
+	"49,31": {
+		"terrainType": "LAND"
+	},
+	"49,32": {
+		"terrainType": "LAND"
+	},
+	"49,33": {
+		"terrainType": "LAND"
+	},
+	"49,34": {
+		"terrainType": "LAND"
+	},
+	"49,35": {
+		"terrainType": "LAND"
+	},
+	"49,36": {
+		"terrainType": "LAND"
+	},
+	"49,37": {
+		"terrainType": "LAND"
+	},
+	"49,38": {
+		"terrainType": "LAND"
+	},
+	"49,39": {
+		"terrainType": "LAND"
+	},
+	"49,40": {
+		"terrainType": "LAND"
+	},
+	"49,41": {
+		"terrainType": "LAND"
+	},
+	"49,42": {
+		"terrainType": "LAND"
+	},
+	"49,43": {
+		"terrainType": "LAND"
+	},
+	"49,44": {
+		"terrainType": "LAND"
+	},
+	"49,45": {
+		"terrainType": "LAND"
+	},
+	"49,46": {
+		"terrainType": "LAND"
+	},
+	"49,47": {
+		"terrainType": "LAND"
+	},
+	"49,48": {
+		"terrainType": "LAND"
+	},
+	"49,49": {
+		"terrainType": "LAND"
+	},
+	"49,50": {
+		"terrainType": "LAND"
+	},
+	"49,51": {
+		"terrainType": "LAND"
+	},
+	"49,52": {
+		"terrainType": "LAND"
+	},
+	"49,53": {
+		"terrainType": "LAND"
+	},
+	"49,54": {
+		"terrainType": "LAND"
+	},
+	"49,55": {
+		"terrainType": "LAND"
+	},
+	"49,56": {
+		"terrainType": "LAND"
+	},
+	"49,57": {
+		"terrainType": "LAND"
+	},
+	"49,58": {
+		"terrainType": "LAND"
+	},
+	"49,59": {
+		"terrainType": "LAND"
+	},
+	"49,60": {
+		"terrainType": "LAND"
+	},
+	"49,61": {
+		"terrainType": "LAND"
+	},
+	"49,62": {
+		"terrainType": "LAND"
+	},
+	"49,63": {
+		"terrainType": "LAND"
+	},
+	"50,0": {
+		"terrainType": "LAND"
+	},
+	"50,1": {
+		"terrainType": "LAND"
+	},
+	"50,2": {
+		"terrainType": "LAND"
+	},
+	"50,3": {
+		"terrainType": "LAND"
+	},
+	"50,4": {
+		"terrainType": "LAND"
+	},
+	"50,5": {
+		"terrainType": "LAND"
+	},
+	"50,6": {
+		"terrainType": "LAND"
+	},
+	"50,7": {
+		"terrainType": "LAND"
+	},
+	"50,8": {
+		"terrainType": "LAND"
+	},
+	"50,9": {
+		"terrainType": "LAND"
+	},
+	"50,10": {
+		"terrainType": "LAND"
+	},
+	"50,11": {
+		"terrainType": "LAND"
+	},
+	"50,12": {
+		"terrainType": "LAND"
+	},
+	"50,13": {
+		"terrainType": "LAND"
+	},
+	"50,14": {
+		"terrainType": "LAND"
+	},
+	"50,15": {
+		"terrainType": "LAND"
+	},
+	"50,16": {
+		"terrainType": "LAND"
+	},
+	"50,17": {
+		"terrainType": "LAND"
+	},
+	"50,18": {
+		"terrainType": "LAND"
+	},
+	"50,19": {
+		"terrainType": "LAND"
+	},
+	"50,20": {
+		"terrainType": "LAND"
+	},
+	"50,21": {
+		"terrainType": "LAND"
+	},
+	"50,22": {
+		"terrainType": "LAND"
+	},
+	"50,23": {
+		"terrainType": "LAND"
+	},
+	"50,24": {
+		"terrainType": "LAND"
+	},
+	"50,25": {
+		"terrainType": "LAND"
+	},
+	"50,26": {
+		"terrainType": "LAND"
+	},
+	"50,27": {
+		"terrainType": "LAND"
+	},
+	"50,28": {
+		"terrainType": "LAND"
+	},
+	"50,29": {
+		"terrainType": "LAND"
+	},
+	"50,30": {
+		"terrainType": "LAND"
+	},
+	"50,31": {
+		"terrainType": "LAND"
+	},
+	"50,32": {
+		"terrainType": "LAND"
+	},
+	"50,33": {
+		"terrainType": "LAND"
+	},
+	"50,34": {
+		"terrainType": "LAND"
+	},
+	"50,35": {
+		"terrainType": "LAND"
+	},
+	"50,36": {
+		"terrainType": "LAND"
+	},
+	"50,37": {
+		"terrainType": "LAND"
+	},
+	"50,38": {
+		"terrainType": "LAND"
+	},
+	"50,39": {
+		"terrainType": "LAND"
+	},
+	"50,40": {
+		"terrainType": "LAND"
+	},
+	"50,41": {
+		"terrainType": "LAND"
+	},
+	"50,42": {
+		"terrainType": "LAND"
+	},
+	"50,43": {
+		"terrainType": "LAND"
+	},
+	"50,44": {
+		"terrainType": "LAND"
+	},
+	"50,45": {
+		"terrainType": "LAND"
+	},
+	"50,46": {
+		"terrainType": "LAND"
+	},
+	"50,47": {
+		"terrainType": "LAND"
+	},
+	"50,48": {
+		"terrainType": "LAND"
+	},
+	"50,49": {
+		"terrainType": "LAND"
+	},
+	"50,50": {
+		"terrainType": "LAND"
+	},
+	"50,51": {
+		"terrainType": "LAND"
+	},
+	"50,52": {
+		"terrainType": "LAND"
+	},
+	"50,53": {
+		"terrainType": "LAND"
+	},
+	"50,54": {
+		"terrainType": "LAND"
+	},
+	"50,55": {
+		"terrainType": "LAND"
+	},
+	"50,56": {
+		"terrainType": "LAND"
+	},
+	"50,57": {
+		"terrainType": "LAND"
+	},
+	"50,58": {
+		"terrainType": "LAND"
+	},
+	"50,59": {
+		"terrainType": "LAND"
+	},
+	"50,60": {
+		"terrainType": "LAND"
+	},
+	"50,61": {
+		"terrainType": "LAND"
+	},
+	"50,62": {
+		"terrainType": "LAND"
+	},
+	"50,63": {
+		"terrainType": "LAND"
+	},
+	"51,0": {
+		"terrainType": "LAND"
+	},
+	"51,1": {
+		"terrainType": "LAND"
+	},
+	"51,2": {
+		"terrainType": "LAND"
+	},
+	"51,3": {
+		"terrainType": "LAND"
+	},
+	"51,4": {
+		"terrainType": "LAND"
+	},
+	"51,5": {
+		"terrainType": "LAND"
+	},
+	"51,6": {
+		"terrainType": "LAND"
+	},
+	"51,7": {
+		"terrainType": "LAND"
+	},
+	"51,8": {
+		"terrainType": "LAND"
+	},
+	"51,9": {
+		"terrainType": "LAND"
+	},
+	"51,10": {
+		"terrainType": "LAND"
+	},
+	"51,11": {
+		"terrainType": "LAND"
+	},
+	"51,12": {
+		"terrainType": "LAND"
+	},
+	"51,13": {
+		"terrainType": "LAND"
+	},
+	"51,14": {
+		"terrainType": "LAND"
+	},
+	"51,15": {
+		"terrainType": "LAND"
+	},
+	"51,16": {
+		"terrainType": "LAND"
+	},
+	"51,17": {
+		"terrainType": "LAND"
+	},
+	"51,18": {
+		"terrainType": "LAND"
+	},
+	"51,19": {
+		"terrainType": "LAND"
+	},
+	"51,20": {
+		"terrainType": "LAND"
+	},
+	"51,21": {
+		"terrainType": "LAND"
+	},
+	"51,22": {
+		"terrainType": "LAND"
+	},
+	"51,23": {
+		"terrainType": "LAND"
+	},
+	"51,24": {
+		"terrainType": "LAND"
+	},
+	"51,25": {
+		"terrainType": "LAND"
+	},
+	"51,26": {
+		"terrainType": "LAND"
+	},
+	"51,27": {
+		"terrainType": "LAND"
+	},
+	"51,28": {
+		"terrainType": "LAND"
+	},
+	"51,29": {
+		"terrainType": "LAND"
+	},
+	"51,30": {
+		"terrainType": "LAND"
+	},
+	"51,31": {
+		"terrainType": "LAND"
+	},
+	"51,32": {
+		"terrainType": "LAND"
+	},
+	"51,33": {
+		"terrainType": "LAND"
+	},
+	"51,34": {
+		"terrainType": "LAND"
+	},
+	"51,35": {
+		"terrainType": "LAND"
+	},
+	"51,36": {
+		"terrainType": "LAND"
+	},
+	"51,37": {
+		"terrainType": "LAND"
+	},
+	"51,38": {
+		"terrainType": "LAND"
+	},
+	"51,39": {
+		"terrainType": "LAND"
+	},
+	"51,40": {
+		"terrainType": "LAND"
+	},
+	"51,41": {
+		"terrainType": "LAND"
+	},
+	"51,42": {
+		"terrainType": "LAND"
+	},
+	"51,43": {
+		"terrainType": "LAND"
+	},
+	"51,44": {
+		"terrainType": "LAND"
+	},
+	"51,45": {
+		"terrainType": "LAND"
+	},
+	"51,46": {
+		"terrainType": "LAND"
+	},
+	"51,47": {
+		"terrainType": "LAND"
+	},
+	"51,48": {
+		"terrainType": "LAND"
+	},
+	"51,49": {
+		"terrainType": "LAND"
+	},
+	"51,50": {
+		"terrainType": "LAND"
+	},
+	"51,51": {
+		"terrainType": "LAND"
+	},
+	"51,52": {
+		"terrainType": "LAND"
+	},
+	"51,53": {
+		"terrainType": "LAND"
+	},
+	"51,54": {
+		"terrainType": "LAND"
+	},
+	"51,55": {
+		"terrainType": "LAND"
+	},
+	"51,56": {
+		"terrainType": "LAND"
+	},
+	"51,57": {
+		"terrainType": "LAND"
+	},
+	"51,58": {
+		"terrainType": "LAND"
+	},
+	"51,59": {
+		"terrainType": "LAND"
+	},
+	"51,60": {
+		"terrainType": "LAND"
+	},
+	"51,61": {
+		"terrainType": "LAND"
+	},
+	"51,62": {
+		"terrainType": "LAND"
+	},
+	"51,63": {
+		"terrainType": "LAND"
+	},
+	"52,0": {
+		"terrainType": "LAND"
+	},
+	"52,1": {
+		"terrainType": "LAND"
+	},
+	"52,2": {
+		"terrainType": "LAND"
+	},
+	"52,3": {
+		"terrainType": "LAND"
+	},
+	"52,4": {
+		"terrainType": "LAND"
+	},
+	"52,5": {
+		"terrainType": "LAND"
+	},
+	"52,6": {
+		"terrainType": "LAND"
+	},
+	"52,7": {
+		"terrainType": "LAND"
+	},
+	"52,8": {
+		"terrainType": "LAND"
+	},
+	"52,9": {
+		"terrainType": "LAND"
+	},
+	"52,10": {
+		"terrainType": "LAND"
+	},
+	"52,11": {
+		"terrainType": "LAND"
+	},
+	"52,12": {
+		"terrainType": "LAND"
+	},
+	"52,13": {
+		"terrainType": "LAND"
+	},
+	"52,14": {
+		"terrainType": "LAND"
+	},
+	"52,15": {
+		"terrainType": "LAND"
+	},
+	"52,16": {
+		"terrainType": "LAND"
+	},
+	"52,17": {
+		"terrainType": "LAND"
+	},
+	"52,18": {
+		"terrainType": "LAND"
+	},
+	"52,19": {
+		"terrainType": "LAND"
+	},
+	"52,20": {
+		"terrainType": "LAND"
+	},
+	"52,21": {
+		"terrainType": "LAND"
+	},
+	"52,22": {
+		"terrainType": "LAND"
+	},
+	"52,23": {
+		"terrainType": "LAND"
+	},
+	"52,24": {
+		"terrainType": "LAND"
+	},
+	"52,25": {
+		"terrainType": "LAND"
+	},
+	"52,26": {
+		"terrainType": "LAND"
+	},
+	"52,27": {
+		"terrainType": "LAND"
+	},
+	"52,28": {
+		"terrainType": "LAND"
+	},
+	"52,29": {
+		"terrainType": "LAND"
+	},
+	"52,30": {
+		"terrainType": "LAND"
+	},
+	"52,31": {
+		"terrainType": "LAND"
+	},
+	"52,32": {
+		"terrainType": "LAND"
+	},
+	"52,33": {
+		"terrainType": "LAND"
+	},
+	"52,34": {
+		"terrainType": "LAND"
+	},
+	"52,35": {
+		"terrainType": "LAND"
+	},
+	"52,36": {
+		"terrainType": "LAND"
+	},
+	"52,37": {
+		"terrainType": "LAND"
+	},
+	"52,38": {
+		"terrainType": "LAND"
+	},
+	"52,39": {
+		"terrainType": "LAND"
+	},
+	"52,40": {
+		"terrainType": "LAND"
+	},
+	"52,41": {
+		"terrainType": "LAND"
+	},
+	"52,42": {
+		"terrainType": "LAND"
+	},
+	"52,43": {
+		"terrainType": "LAND"
+	},
+	"52,44": {
+		"terrainType": "LAND"
+	},
+	"52,45": {
+		"terrainType": "LAND"
+	},
+	"52,46": {
+		"terrainType": "LAND"
+	},
+	"52,47": {
+		"terrainType": "LAND"
+	},
+	"52,48": {
+		"terrainType": "LAND"
+	},
+	"52,49": {
+		"terrainType": "LAND"
+	},
+	"52,50": {
+		"terrainType": "LAND"
+	},
+	"52,51": {
+		"terrainType": "LAND"
+	},
+	"52,52": {
+		"terrainType": "LAND"
+	},
+	"52,53": {
+		"terrainType": "LAND"
+	},
+	"52,54": {
+		"terrainType": "LAND"
+	},
+	"52,55": {
+		"terrainType": "LAND"
+	},
+	"52,56": {
+		"terrainType": "LAND"
+	},
+	"52,57": {
+		"terrainType": "LAND"
+	},
+	"52,58": {
+		"terrainType": "LAND"
+	},
+	"52,59": {
+		"terrainType": "LAND"
+	},
+	"52,60": {
+		"terrainType": "LAND"
+	},
+	"52,61": {
+		"terrainType": "LAND"
+	},
+	"52,62": {
+		"terrainType": "LAND"
+	},
+	"52,63": {
+		"terrainType": "LAND"
+	},
+	"53,0": {
+		"terrainType": "LAND"
+	},
+	"53,1": {
+		"terrainType": "LAND"
+	},
+	"53,2": {
+		"terrainType": "LAND"
+	},
+	"53,3": {
+		"terrainType": "LAND"
+	},
+	"53,4": {
+		"terrainType": "LAND"
+	},
+	"53,5": {
+		"terrainType": "LAND"
+	},
+	"53,6": {
+		"terrainType": "LAND"
+	},
+	"53,7": {
+		"terrainType": "LAND"
+	},
+	"53,8": {
+		"terrainType": "LAND"
+	},
+	"53,9": {
+		"terrainType": "LAND"
+	},
+	"53,10": {
+		"terrainType": "LAND"
+	},
+	"53,11": {
+		"terrainType": "LAND"
+	},
+	"53,12": {
+		"terrainType": "LAND"
+	},
+	"53,13": {
+		"terrainType": "LAND"
+	},
+	"53,14": {
+		"terrainType": "LAND"
+	},
+	"53,15": {
+		"terrainType": "LAND"
+	},
+	"53,16": {
+		"terrainType": "LAND"
+	},
+	"53,17": {
+		"terrainType": "LAND"
+	},
+	"53,18": {
+		"terrainType": "LAND"
+	},
+	"53,19": {
+		"terrainType": "LAND"
+	},
+	"53,20": {
+		"terrainType": "LAND"
+	},
+	"53,21": {
+		"terrainType": "LAND"
+	},
+	"53,22": {
+		"terrainType": "LAND"
+	},
+	"53,23": {
+		"terrainType": "LAND"
+	},
+	"53,24": {
+		"terrainType": "LAND"
+	},
+	"53,25": {
+		"terrainType": "LAND"
+	},
+	"53,26": {
+		"terrainType": "LAND"
+	},
+	"53,27": {
+		"terrainType": "LAND"
+	},
+	"53,28": {
+		"terrainType": "LAND"
+	},
+	"53,29": {
+		"terrainType": "LAND"
+	},
+	"53,30": {
+		"terrainType": "LAND"
+	},
+	"53,31": {
+		"terrainType": "LAND"
+	},
+	"53,32": {
+		"terrainType": "LAND"
+	},
+	"53,33": {
+		"terrainType": "LAND"
+	},
+	"53,34": {
+		"terrainType": "LAND"
+	},
+	"53,35": {
+		"terrainType": "LAND"
+	},
+	"53,36": {
+		"terrainType": "LAND"
+	},
+	"53,37": {
+		"terrainType": "LAND"
+	},
+	"53,38": {
+		"terrainType": "LAND"
+	},
+	"53,39": {
+		"terrainType": "LAND"
+	},
+	"53,40": {
+		"terrainType": "LAND"
+	},
+	"53,41": {
+		"terrainType": "LAND"
+	},
+	"53,42": {
+		"terrainType": "LAND"
+	},
+	"53,43": {
+		"terrainType": "LAND"
+	},
+	"53,44": {
+		"terrainType": "LAND"
+	},
+	"53,45": {
+		"terrainType": "LAND"
+	},
+	"53,46": {
+		"terrainType": "LAND"
+	},
+	"53,47": {
+		"terrainType": "LAND"
+	},
+	"53,48": {
+		"terrainType": "LAND"
+	},
+	"53,49": {
+		"terrainType": "LAND"
+	},
+	"53,50": {
+		"terrainType": "LAND"
+	},
+	"53,51": {
+		"terrainType": "LAND"
+	},
+	"53,52": {
+		"terrainType": "LAND"
+	},
+	"53,53": {
+		"terrainType": "LAND"
+	},
+	"53,54": {
+		"terrainType": "LAND"
+	},
+	"53,55": {
+		"terrainType": "LAND"
+	},
+	"53,56": {
+		"terrainType": "LAND"
+	},
+	"53,57": {
+		"terrainType": "LAND"
+	},
+	"53,58": {
+		"terrainType": "LAND"
+	},
+	"53,59": {
+		"terrainType": "LAND"
+	},
+	"53,60": {
+		"terrainType": "LAND"
+	},
+	"53,61": {
+		"terrainType": "LAND"
+	},
+	"53,62": {
+		"terrainType": "LAND"
+	},
+	"53,63": {
+		"terrainType": "LAND"
+	},
+	"54,0": {
+		"terrainType": "LAND"
+	},
+	"54,1": {
+		"terrainType": "LAND"
+	},
+	"54,2": {
+		"terrainType": "LAND"
+	},
+	"54,3": {
+		"terrainType": "LAND"
+	},
+	"54,4": {
+		"terrainType": "LAND"
+	},
+	"54,5": {
+		"terrainType": "LAND"
+	},
+	"54,6": {
+		"terrainType": "LAND"
+	},
+	"54,7": {
+		"terrainType": "LAND"
+	},
+	"54,8": {
+		"terrainType": "LAND"
+	},
+	"54,9": {
+		"terrainType": "LAND"
+	},
+	"54,10": {
+		"terrainType": "LAND"
+	},
+	"54,11": {
+		"terrainType": "LAND"
+	},
+	"54,12": {
+		"terrainType": "LAND"
+	},
+	"54,13": {
+		"terrainType": "LAND"
+	},
+	"54,14": {
+		"terrainType": "LAND"
+	},
+	"54,15": {
+		"terrainType": "LAND"
+	},
+	"54,16": {
+		"terrainType": "LAND"
+	},
+	"54,17": {
+		"terrainType": "LAND"
+	},
+	"54,18": {
+		"terrainType": "LAND"
+	},
+	"54,19": {
+		"terrainType": "LAND"
+	},
+	"54,20": {
+		"terrainType": "LAND"
+	},
+	"54,21": {
+		"terrainType": "LAND"
+	},
+	"54,22": {
+		"terrainType": "LAND"
+	},
+	"54,23": {
+		"terrainType": "LAND"
+	},
+	"54,24": {
+		"terrainType": "LAND"
+	},
+	"54,25": {
+		"terrainType": "LAND"
+	},
+	"54,26": {
+		"terrainType": "LAND"
+	},
+	"54,27": {
+		"terrainType": "LAND"
+	},
+	"54,28": {
+		"terrainType": "LAND"
+	},
+	"54,29": {
+		"terrainType": "LAND"
+	},
+	"54,30": {
+		"terrainType": "LAND"
+	},
+	"54,31": {
+		"terrainType": "LAND"
+	},
+	"54,32": {
+		"terrainType": "LAND"
+	},
+	"54,33": {
+		"terrainType": "LAND"
+	},
+	"54,34": {
+		"terrainType": "LAND"
+	},
+	"54,35": {
+		"terrainType": "LAND"
+	},
+	"54,36": {
+		"terrainType": "LAND"
+	},
+	"54,37": {
+		"terrainType": "LAND"
+	},
+	"54,38": {
+		"terrainType": "LAND"
+	},
+	"54,39": {
+		"terrainType": "LAND"
+	},
+	"54,40": {
+		"terrainType": "LAND"
+	},
+	"54,41": {
+		"terrainType": "LAND"
+	},
+	"54,42": {
+		"terrainType": "LAND"
+	},
+	"54,43": {
+		"terrainType": "LAND"
+	},
+	"54,44": {
+		"terrainType": "LAND"
+	},
+	"54,45": {
+		"terrainType": "LAND"
+	},
+	"54,46": {
+		"terrainType": "LAND"
+	},
+	"54,47": {
+		"terrainType": "LAND"
+	},
+	"54,48": {
+		"terrainType": "LAND"
+	},
+	"54,49": {
+		"terrainType": "LAND"
+	},
+	"54,50": {
+		"terrainType": "LAND"
+	},
+	"54,51": {
+		"terrainType": "LAND"
+	},
+	"54,52": {
+		"terrainType": "LAND"
+	},
+	"54,53": {
+		"terrainType": "LAND"
+	},
+	"54,54": {
+		"terrainType": "LAND"
+	},
+	"54,55": {
+		"terrainType": "LAND"
+	},
+	"54,56": {
+		"terrainType": "LAND"
+	},
+	"54,57": {
+		"terrainType": "LAND"
+	},
+	"54,58": {
+		"terrainType": "LAND"
+	},
+	"54,59": {
+		"terrainType": "LAND"
+	},
+	"54,60": {
+		"terrainType": "LAND"
+	},
+	"54,61": {
+		"terrainType": "LAND"
+	},
+	"54,62": {
+		"terrainType": "LAND"
+	},
+	"54,63": {
+		"terrainType": "LAND"
+	},
+	"55,0": {
+		"terrainType": "LAND"
+	},
+	"55,1": {
+		"terrainType": "LAND"
+	},
+	"55,2": {
+		"terrainType": "LAND"
+	},
+	"55,3": {
+		"terrainType": "LAND"
+	},
+	"55,4": {
+		"terrainType": "LAND"
+	},
+	"55,5": {
+		"terrainType": "LAND"
+	},
+	"55,6": {
+		"terrainType": "LAND"
+	},
+	"55,7": {
+		"terrainType": "LAND"
+	},
+	"55,8": {
+		"terrainType": "LAND"
+	},
+	"55,9": {
+		"terrainType": "LAND"
+	},
+	"55,10": {
+		"terrainType": "LAND"
+	},
+	"55,11": {
+		"terrainType": "LAND"
+	},
+	"55,12": {
+		"terrainType": "LAND"
+	},
+	"55,13": {
+		"terrainType": "LAND"
+	},
+	"55,14": {
+		"terrainType": "LAND"
+	},
+	"55,15": {
+		"terrainType": "LAND"
+	},
+	"55,16": {
+		"terrainType": "LAND"
+	},
+	"55,17": {
+		"terrainType": "LAND"
+	},
+	"55,18": {
+		"terrainType": "LAND"
+	},
+	"55,19": {
+		"terrainType": "LAND"
+	},
+	"55,20": {
+		"terrainType": "LAND"
+	},
+	"55,21": {
+		"terrainType": "LAND"
+	},
+	"55,22": {
+		"terrainType": "LAND"
+	},
+	"55,23": {
+		"terrainType": "LAND"
+	},
+	"55,24": {
+		"terrainType": "LAND"
+	},
+	"55,25": {
+		"terrainType": "LAND"
+	},
+	"55,26": {
+		"terrainType": "LAND"
+	},
+	"55,27": {
+		"terrainType": "LAND"
+	},
+	"55,28": {
+		"terrainType": "LAND"
+	},
+	"55,29": {
+		"terrainType": "LAND"
+	},
+	"55,30": {
+		"terrainType": "LAND"
+	},
+	"55,31": {
+		"terrainType": "LAND"
+	},
+	"55,32": {
+		"terrainType": "LAND"
+	},
+	"55,33": {
+		"terrainType": "LAND"
+	},
+	"55,34": {
+		"terrainType": "LAND"
+	},
+	"55,35": {
+		"terrainType": "LAND"
+	},
+	"55,36": {
+		"terrainType": "LAND"
+	},
+	"55,37": {
+		"terrainType": "LAND"
+	},
+	"55,38": {
+		"terrainType": "LAND"
+	},
+	"55,39": {
+		"terrainType": "LAND"
+	},
+	"55,40": {
+		"terrainType": "LAND"
+	},
+	"55,41": {
+		"terrainType": "LAND"
+	},
+	"55,42": {
+		"terrainType": "LAND"
+	},
+	"55,43": {
+		"terrainType": "LAND"
+	},
+	"55,44": {
+		"terrainType": "LAND"
+	},
+	"55,45": {
+		"terrainType": "LAND"
+	},
+	"55,46": {
+		"terrainType": "LAND"
+	},
+	"55,47": {
+		"terrainType": "LAND"
+	},
+	"55,48": {
+		"terrainType": "LAND"
+	},
+	"55,49": {
+		"terrainType": "LAND"
+	},
+	"55,50": {
+		"terrainType": "LAND"
+	},
+	"55,51": {
+		"terrainType": "LAND"
+	},
+	"55,52": {
+		"terrainType": "LAND"
+	},
+	"55,53": {
+		"terrainType": "LAND"
+	},
+	"55,54": {
+		"terrainType": "LAND"
+	},
+	"55,55": {
+		"terrainType": "LAND"
+	},
+	"55,56": {
+		"terrainType": "LAND"
+	},
+	"55,57": {
+		"terrainType": "LAND"
+	},
+	"55,58": {
+		"terrainType": "LAND"
+	},
+	"55,59": {
+		"terrainType": "LAND"
+	},
+	"55,60": {
+		"terrainType": "LAND"
+	},
+	"55,61": {
+		"terrainType": "LAND"
+	},
+	"55,62": {
+		"terrainType": "LAND"
+	},
+	"55,63": {
+		"terrainType": "LAND"
+	},
+	"56,0": {
+		"terrainType": "LAND"
+	},
+	"56,1": {
+		"terrainType": "LAND"
+	},
+	"56,2": {
+		"terrainType": "LAND"
+	},
+	"56,3": {
+		"terrainType": "LAND"
+	},
+	"56,4": {
+		"terrainType": "LAND"
+	},
+	"56,5": {
+		"terrainType": "LAND"
+	},
+	"56,6": {
+		"terrainType": "LAND"
+	},
+	"56,7": {
+		"terrainType": "LAND"
+	},
+	"56,8": {
+		"terrainType": "LAND"
+	},
+	"56,9": {
+		"terrainType": "LAND"
+	},
+	"56,10": {
+		"terrainType": "LAND"
+	},
+	"56,11": {
+		"terrainType": "LAND"
+	},
+	"56,12": {
+		"terrainType": "LAND"
+	},
+	"56,13": {
+		"terrainType": "LAND"
+	},
+	"56,14": {
+		"terrainType": "LAND"
+	},
+	"56,15": {
+		"terrainType": "LAND"
+	},
+	"56,16": {
+		"terrainType": "LAND"
+	},
+	"56,17": {
+		"terrainType": "LAND"
+	},
+	"56,18": {
+		"terrainType": "LAND"
+	},
+	"56,19": {
+		"terrainType": "LAND"
+	},
+	"56,20": {
+		"terrainType": "LAND"
+	},
+	"56,21": {
+		"terrainType": "LAND"
+	},
+	"56,22": {
+		"terrainType": "LAND"
+	},
+	"56,23": {
+		"terrainType": "LAND"
+	},
+	"56,24": {
+		"terrainType": "LAND"
+	},
+	"56,25": {
+		"terrainType": "LAND"
+	},
+	"56,26": {
+		"terrainType": "LAND"
+	},
+	"56,27": {
+		"terrainType": "LAND"
+	},
+	"56,28": {
+		"terrainType": "LAND"
+	},
+	"56,29": {
+		"terrainType": "LAND"
+	},
+	"56,30": {
+		"terrainType": "LAND"
+	},
+	"56,31": {
+		"terrainType": "LAND"
+	},
+	"56,32": {
+		"terrainType": "LAND"
+	},
+	"56,33": {
+		"terrainType": "LAND"
+	},
+	"56,34": {
+		"terrainType": "LAND"
+	},
+	"56,35": {
+		"terrainType": "LAND"
+	},
+	"56,36": {
+		"terrainType": "LAND"
+	},
+	"56,37": {
+		"terrainType": "LAND"
+	},
+	"56,38": {
+		"terrainType": "LAND"
+	},
+	"56,39": {
+		"terrainType": "LAND"
+	},
+	"56,40": {
+		"terrainType": "LAND"
+	},
+	"56,41": {
+		"terrainType": "LAND"
+	},
+	"56,42": {
+		"terrainType": "LAND"
+	},
+	"56,43": {
+		"terrainType": "LAND"
+	},
+	"56,44": {
+		"terrainType": "LAND"
+	},
+	"56,45": {
+		"terrainType": "LAND"
+	},
+	"56,46": {
+		"terrainType": "LAND"
+	},
+	"56,47": {
+		"terrainType": "LAND"
+	},
+	"56,48": {
+		"terrainType": "LAND"
+	},
+	"56,49": {
+		"terrainType": "LAND"
+	},
+	"56,50": {
+		"terrainType": "LAND"
+	},
+	"56,51": {
+		"terrainType": "LAND"
+	},
+	"56,52": {
+		"terrainType": "LAND"
+	},
+	"56,53": {
+		"terrainType": "LAND"
+	},
+	"56,54": {
+		"terrainType": "LAND"
+	},
+	"56,55": {
+		"terrainType": "LAND"
+	},
+	"56,56": {
+		"terrainType": "LAND"
+	},
+	"56,57": {
+		"terrainType": "LAND"
+	},
+	"56,58": {
+		"terrainType": "LAND"
+	},
+	"56,59": {
+		"terrainType": "LAND"
+	},
+	"56,60": {
+		"terrainType": "LAND"
+	},
+	"56,61": {
+		"terrainType": "LAND"
+	},
+	"56,62": {
+		"terrainType": "LAND"
+	},
+	"56,63": {
+		"terrainType": "LAND"
+	},
+	"57,0": {
+		"terrainType": "LAND"
+	},
+	"57,1": {
+		"terrainType": "LAND"
+	},
+	"57,2": {
+		"terrainType": "LAND"
+	},
+	"57,3": {
+		"terrainType": "LAND"
+	},
+	"57,4": {
+		"terrainType": "LAND"
+	},
+	"57,5": {
+		"terrainType": "LAND"
+	},
+	"57,6": {
+		"terrainType": "LAND"
+	},
+	"57,7": {
+		"terrainType": "LAND"
+	},
+	"57,8": {
+		"terrainType": "LAND"
+	},
+	"57,9": {
+		"terrainType": "LAND"
+	},
+	"57,10": {
+		"terrainType": "LAND"
+	},
+	"57,11": {
+		"terrainType": "LAND"
+	},
+	"57,12": {
+		"terrainType": "LAND"
+	},
+	"57,13": {
+		"terrainType": "LAND"
+	},
+	"57,14": {
+		"terrainType": "LAND"
+	},
+	"57,15": {
+		"terrainType": "LAND"
+	},
+	"57,16": {
+		"terrainType": "LAND"
+	},
+	"57,17": {
+		"terrainType": "LAND"
+	},
+	"57,18": {
+		"terrainType": "LAND"
+	},
+	"57,19": {
+		"terrainType": "LAND"
+	},
+	"57,20": {
+		"terrainType": "LAND"
+	},
+	"57,21": {
+		"terrainType": "LAND"
+	},
+	"57,22": {
+		"terrainType": "LAND"
+	},
+	"57,23": {
+		"terrainType": "LAND"
+	},
+	"57,24": {
+		"terrainType": "LAND"
+	},
+	"57,25": {
+		"terrainType": "LAND"
+	},
+	"57,26": {
+		"terrainType": "LAND"
+	},
+	"57,27": {
+		"terrainType": "LAND"
+	},
+	"57,28": {
+		"terrainType": "LAND"
+	},
+	"57,29": {
+		"terrainType": "LAND"
+	},
+	"57,30": {
+		"terrainType": "LAND"
+	},
+	"57,31": {
+		"terrainType": "LAND"
+	},
+	"57,32": {
+		"terrainType": "LAND"
+	},
+	"57,33": {
+		"terrainType": "LAND"
+	},
+	"57,34": {
+		"terrainType": "LAND"
+	},
+	"57,35": {
+		"terrainType": "LAND"
+	},
+	"57,36": {
+		"terrainType": "LAND"
+	},
+	"57,37": {
+		"terrainType": "LAND"
+	},
+	"57,38": {
+		"terrainType": "LAND"
+	},
+	"57,39": {
+		"terrainType": "LAND"
+	},
+	"57,40": {
+		"terrainType": "LAND"
+	},
+	"57,41": {
+		"terrainType": "LAND"
+	},
+	"57,42": {
+		"terrainType": "LAND"
+	},
+	"57,43": {
+		"terrainType": "LAND"
+	},
+	"57,44": {
+		"terrainType": "LAND"
+	},
+	"57,45": {
+		"terrainType": "LAND"
+	},
+	"57,46": {
+		"terrainType": "LAND"
+	},
+	"57,47": {
+		"terrainType": "LAND"
+	},
+	"57,48": {
+		"terrainType": "LAND"
+	},
+	"57,49": {
+		"terrainType": "LAND"
+	},
+	"57,50": {
+		"terrainType": "LAND"
+	},
+	"57,51": {
+		"terrainType": "LAND"
+	},
+	"57,52": {
+		"terrainType": "LAND"
+	},
+	"57,53": {
+		"terrainType": "LAND"
+	},
+	"57,54": {
+		"terrainType": "LAND"
+	},
+	"57,55": {
+		"terrainType": "LAND"
+	},
+	"57,56": {
+		"terrainType": "LAND"
+	},
+	"57,57": {
+		"terrainType": "LAND"
+	},
+	"57,58": {
+		"terrainType": "LAND"
+	},
+	"57,59": {
+		"terrainType": "LAND"
+	},
+	"57,60": {
+		"terrainType": "LAND"
+	},
+	"57,61": {
+		"terrainType": "LAND"
+	},
+	"57,62": {
+		"terrainType": "LAND"
+	},
+	"57,63": {
+		"terrainType": "LAND"
+	},
+	"58,0": {
+		"terrainType": "LAND"
+	},
+	"58,1": {
+		"terrainType": "LAND"
+	},
+	"58,2": {
+		"terrainType": "LAND"
+	},
+	"58,3": {
+		"terrainType": "LAND"
+	},
+	"58,4": {
+		"terrainType": "LAND"
+	},
+	"58,5": {
+		"terrainType": "LAND"
+	},
+	"58,6": {
+		"terrainType": "LAND"
+	},
+	"58,7": {
+		"terrainType": "LAND"
+	},
+	"58,8": {
+		"terrainType": "LAND"
+	},
+	"58,9": {
+		"terrainType": "LAND"
+	},
+	"58,10": {
+		"terrainType": "LAND"
+	},
+	"58,11": {
+		"terrainType": "LAND"
+	},
+	"58,12": {
+		"terrainType": "LAND"
+	},
+	"58,13": {
+		"terrainType": "LAND"
+	},
+	"58,14": {
+		"terrainType": "LAND"
+	},
+	"58,15": {
+		"terrainType": "LAND"
+	},
+	"58,16": {
+		"terrainType": "LAND"
+	},
+	"58,17": {
+		"terrainType": "LAND"
+	},
+	"58,18": {
+		"terrainType": "LAND"
+	},
+	"58,19": {
+		"terrainType": "LAND"
+	},
+	"58,20": {
+		"terrainType": "LAND"
+	},
+	"58,21": {
+		"terrainType": "LAND"
+	},
+	"58,22": {
+		"terrainType": "LAND"
+	},
+	"58,23": {
+		"terrainType": "LAND"
+	},
+	"58,24": {
+		"terrainType": "LAND"
+	},
+	"58,25": {
+		"terrainType": "LAND"
+	},
+	"58,26": {
+		"terrainType": "LAND"
+	},
+	"58,27": {
+		"terrainType": "LAND"
+	},
+	"58,28": {
+		"terrainType": "LAND"
+	},
+	"58,29": {
+		"terrainType": "LAND"
+	},
+	"58,30": {
+		"terrainType": "LAND"
+	},
+	"58,31": {
+		"terrainType": "LAND"
+	},
+	"58,32": {
+		"terrainType": "LAND"
+	},
+	"58,33": {
+		"terrainType": "LAND"
+	},
+	"58,34": {
+		"terrainType": "LAND"
+	},
+	"58,35": {
+		"terrainType": "LAND"
+	},
+	"58,36": {
+		"terrainType": "LAND"
+	},
+	"58,37": {
+		"terrainType": "LAND"
+	},
+	"58,38": {
+		"terrainType": "LAND"
+	},
+	"58,39": {
+		"terrainType": "LAND"
+	},
+	"58,40": {
+		"terrainType": "LAND"
+	},
+	"58,41": {
+		"terrainType": "LAND"
+	},
+	"58,42": {
+		"terrainType": "LAND"
+	},
+	"58,43": {
+		"terrainType": "LAND"
+	},
+	"58,44": {
+		"terrainType": "LAND"
+	},
+	"58,45": {
+		"terrainType": "LAND"
+	},
+	"58,46": {
+		"terrainType": "LAND"
+	},
+	"58,47": {
+		"terrainType": "LAND"
+	},
+	"58,48": {
+		"terrainType": "LAND"
+	},
+	"58,49": {
+		"terrainType": "LAND"
+	},
+	"58,50": {
+		"terrainType": "LAND"
+	},
+	"58,51": {
+		"terrainType": "LAND"
+	},
+	"58,52": {
+		"terrainType": "LAND"
+	},
+	"58,53": {
+		"terrainType": "LAND"
+	},
+	"58,54": {
+		"terrainType": "LAND"
+	},
+	"58,55": {
+		"terrainType": "LAND"
+	},
+	"58,56": {
+		"terrainType": "LAND"
+	},
+	"58,57": {
+		"terrainType": "LAND"
+	},
+	"58,58": {
+		"terrainType": "LAND"
+	},
+	"58,59": {
+		"terrainType": "LAND"
+	},
+	"58,60": {
+		"terrainType": "LAND"
+	},
+	"58,61": {
+		"terrainType": "LAND"
+	},
+	"58,62": {
+		"terrainType": "LAND"
+	},
+	"58,63": {
+		"terrainType": "LAND"
+	},
+	"59,0": {
+		"terrainType": "LAND"
+	},
+	"59,1": {
+		"terrainType": "LAND"
+	},
+	"59,2": {
+		"terrainType": "LAND"
+	},
+	"59,3": {
+		"terrainType": "LAND"
+	},
+	"59,4": {
+		"terrainType": "LAND"
+	},
+	"59,5": {
+		"terrainType": "LAND"
+	},
+	"59,6": {
+		"terrainType": "LAND"
+	},
+	"59,7": {
+		"terrainType": "LAND"
+	},
+	"59,8": {
+		"terrainType": "LAND"
+	},
+	"59,9": {
+		"terrainType": "LAND"
+	},
+	"59,10": {
+		"terrainType": "LAND"
+	},
+	"59,11": {
+		"terrainType": "LAND"
+	},
+	"59,12": {
+		"terrainType": "LAND"
+	},
+	"59,13": {
+		"terrainType": "LAND"
+	},
+	"59,14": {
+		"terrainType": "LAND"
+	},
+	"59,15": {
+		"terrainType": "LAND"
+	},
+	"59,16": {
+		"terrainType": "LAND"
+	},
+	"59,17": {
+		"terrainType": "LAND"
+	},
+	"59,18": {
+		"terrainType": "LAND"
+	},
+	"59,19": {
+		"terrainType": "LAND"
+	},
+	"59,20": {
+		"terrainType": "LAND"
+	},
+	"59,21": {
+		"terrainType": "LAND"
+	},
+	"59,22": {
+		"terrainType": "LAND"
+	},
+	"59,23": {
+		"terrainType": "LAND"
+	},
+	"59,24": {
+		"terrainType": "LAND"
+	},
+	"59,25": {
+		"terrainType": "LAND"
+	},
+	"59,26": {
+		"terrainType": "LAND"
+	},
+	"59,27": {
+		"terrainType": "LAND"
+	},
+	"59,28": {
+		"terrainType": "LAND"
+	},
+	"59,29": {
+		"terrainType": "LAND"
+	},
+	"59,30": {
+		"terrainType": "LAND"
+	},
+	"59,31": {
+		"terrainType": "LAND"
+	},
+	"59,32": {
+		"terrainType": "LAND"
+	},
+	"59,33": {
+		"terrainType": "LAND"
+	},
+	"59,34": {
+		"terrainType": "LAND"
+	},
+	"59,35": {
+		"terrainType": "LAND"
+	},
+	"59,36": {
+		"terrainType": "LAND"
+	},
+	"59,37": {
+		"terrainType": "LAND"
+	},
+	"59,38": {
+		"terrainType": "LAND"
+	},
+	"59,39": {
+		"terrainType": "LAND"
+	},
+	"59,40": {
+		"terrainType": "LAND"
+	},
+	"59,41": {
+		"terrainType": "LAND"
+	},
+	"59,42": {
+		"terrainType": "LAND"
+	},
+	"59,43": {
+		"terrainType": "LAND"
+	},
+	"59,44": {
+		"terrainType": "LAND"
+	},
+	"59,45": {
+		"terrainType": "LAND"
+	},
+	"59,46": {
+		"terrainType": "LAND"
+	},
+	"59,47": {
+		"terrainType": "LAND"
+	},
+	"59,48": {
+		"terrainType": "LAND"
+	},
+	"59,49": {
+		"terrainType": "LAND"
+	},
+	"59,50": {
+		"terrainType": "LAND"
+	},
+	"59,51": {
+		"terrainType": "LAND"
+	},
+	"59,52": {
+		"terrainType": "LAND"
+	},
+	"59,53": {
+		"terrainType": "LAND"
+	},
+	"59,54": {
+		"terrainType": "LAND"
+	},
+	"59,55": {
+		"terrainType": "LAND"
+	},
+	"59,56": {
+		"terrainType": "LAND"
+	},
+	"59,57": {
+		"terrainType": "LAND"
+	},
+	"59,58": {
+		"terrainType": "LAND"
+	},
+	"59,59": {
+		"terrainType": "LAND"
+	},
+	"59,60": {
+		"terrainType": "LAND"
+	},
+	"59,61": {
+		"terrainType": "LAND"
+	},
+	"59,62": {
+		"terrainType": "LAND"
+	},
+	"59,63": {
+		"terrainType": "LAND"
+	},
+	"60,0": {
+		"terrainType": "LAND"
+	},
+	"60,1": {
+		"terrainType": "LAND"
+	},
+	"60,2": {
+		"terrainType": "LAND"
+	},
+	"60,3": {
+		"terrainType": "LAND"
+	},
+	"60,4": {
+		"terrainType": "LAND"
+	},
+	"60,5": {
+		"terrainType": "LAND"
+	},
+	"60,6": {
+		"terrainType": "LAND"
+	},
+	"60,7": {
+		"terrainType": "LAND"
+	},
+	"60,8": {
+		"terrainType": "LAND"
+	},
+	"60,9": {
+		"terrainType": "LAND"
+	},
+	"60,10": {
+		"terrainType": "LAND"
+	},
+	"60,11": {
+		"terrainType": "LAND"
+	},
+	"60,12": {
+		"terrainType": "LAND"
+	},
+	"60,13": {
+		"terrainType": "LAND"
+	},
+	"60,14": {
+		"terrainType": "LAND"
+	},
+	"60,15": {
+		"terrainType": "LAND"
+	},
+	"60,16": {
+		"terrainType": "LAND"
+	},
+	"60,17": {
+		"terrainType": "LAND"
+	},
+	"60,18": {
+		"terrainType": "LAND"
+	},
+	"60,19": {
+		"terrainType": "LAND"
+	},
+	"60,20": {
+		"terrainType": "LAND"
+	},
+	"60,21": {
+		"terrainType": "LAND"
+	},
+	"60,22": {
+		"terrainType": "LAND"
+	},
+	"60,23": {
+		"terrainType": "LAND"
+	},
+	"60,24": {
+		"terrainType": "LAND"
+	},
+	"60,25": {
+		"terrainType": "LAND"
+	},
+	"60,26": {
+		"terrainType": "LAND"
+	},
+	"60,27": {
+		"terrainType": "LAND"
+	},
+	"60,28": {
+		"terrainType": "LAND"
+	},
+	"60,29": {
+		"terrainType": "LAND"
+	},
+	"60,30": {
+		"terrainType": "LAND"
+	},
+	"60,31": {
+		"terrainType": "LAND"
+	},
+	"60,32": {
+		"terrainType": "LAND"
+	},
+	"60,33": {
+		"terrainType": "LAND"
+	},
+	"60,34": {
+		"terrainType": "LAND"
+	},
+	"60,35": {
+		"terrainType": "LAND"
+	},
+	"60,36": {
+		"terrainType": "LAND"
+	},
+	"60,37": {
+		"terrainType": "LAND"
+	},
+	"60,38": {
+		"terrainType": "LAND"
+	},
+	"60,39": {
+		"terrainType": "LAND"
+	},
+	"60,40": {
+		"terrainType": "LAND"
+	},
+	"60,41": {
+		"terrainType": "LAND"
+	},
+	"60,42": {
+		"terrainType": "LAND"
+	},
+	"60,43": {
+		"terrainType": "LAND"
+	},
+	"60,44": {
+		"terrainType": "LAND"
+	},
+	"60,45": {
+		"terrainType": "LAND"
+	},
+	"60,46": {
+		"terrainType": "LAND"
+	},
+	"60,47": {
+		"terrainType": "LAND"
+	},
+	"60,48": {
+		"terrainType": "LAND"
+	},
+	"60,49": {
+		"terrainType": "LAND"
+	},
+	"60,50": {
+		"terrainType": "LAND"
+	},
+	"60,51": {
+		"terrainType": "LAND"
+	},
+	"60,52": {
+		"terrainType": "LAND"
+	},
+	"60,53": {
+		"terrainType": "LAND"
+	},
+	"60,54": {
+		"terrainType": "LAND"
+	},
+	"60,55": {
+		"terrainType": "LAND"
+	},
+	"60,56": {
+		"terrainType": "LAND"
+	},
+	"60,57": {
+		"terrainType": "LAND"
+	},
+	"60,58": {
+		"terrainType": "LAND"
+	},
+	"60,59": {
+		"terrainType": "LAND"
+	},
+	"60,60": {
+		"terrainType": "LAND"
+	},
+	"60,61": {
+		"terrainType": "LAND"
+	},
+	"60,62": {
+		"terrainType": "LAND"
+	},
+	"60,63": {
+		"terrainType": "LAND"
+	},
+	"61,0": {
+		"terrainType": "LAND"
+	},
+	"61,1": {
+		"terrainType": "LAND"
+	},
+	"61,2": {
+		"terrainType": "LAND"
+	},
+	"61,3": {
+		"terrainType": "LAND"
+	},
+	"61,4": {
+		"terrainType": "LAND"
+	},
+	"61,5": {
+		"terrainType": "LAND"
+	},
+	"61,6": {
+		"terrainType": "LAND"
+	},
+	"61,7": {
+		"terrainType": "LAND"
+	},
+	"61,8": {
+		"terrainType": "LAND"
+	},
+	"61,9": {
+		"terrainType": "LAND"
+	},
+	"61,10": {
+		"terrainType": "LAND"
+	},
+	"61,11": {
+		"terrainType": "LAND"
+	},
+	"61,12": {
+		"terrainType": "LAND"
+	},
+	"61,13": {
+		"terrainType": "LAND"
+	},
+	"61,14": {
+		"terrainType": "LAND"
+	},
+	"61,15": {
+		"terrainType": "LAND"
+	},
+	"61,16": {
+		"terrainType": "LAND"
+	},
+	"61,17": {
+		"terrainType": "LAND"
+	},
+	"61,18": {
+		"terrainType": "LAND"
+	},
+	"61,19": {
+		"terrainType": "LAND"
+	},
+	"61,20": {
+		"terrainType": "LAND"
+	},
+	"61,21": {
+		"terrainType": "LAND"
+	},
+	"61,22": {
+		"terrainType": "LAND"
+	},
+	"61,23": {
+		"terrainType": "LAND"
+	},
+	"61,24": {
+		"terrainType": "LAND"
+	},
+	"61,25": {
+		"terrainType": "LAND"
+	},
+	"61,26": {
+		"terrainType": "LAND"
+	},
+	"61,27": {
+		"terrainType": "LAND"
+	},
+	"61,28": {
+		"terrainType": "LAND"
+	},
+	"61,29": {
+		"terrainType": "LAND"
+	},
+	"61,30": {
+		"terrainType": "LAND"
+	},
+	"61,31": {
+		"terrainType": "LAND"
+	},
+	"61,32": {
+		"terrainType": "LAND"
+	},
+	"61,33": {
+		"terrainType": "LAND"
+	},
+	"61,34": {
+		"terrainType": "LAND"
+	},
+	"61,35": {
+		"terrainType": "LAND"
+	},
+	"61,36": {
+		"terrainType": "LAND"
+	},
+	"61,37": {
+		"terrainType": "LAND"
+	},
+	"61,38": {
+		"terrainType": "LAND"
+	},
+	"61,39": {
+		"terrainType": "LAND"
+	},
+	"61,40": {
+		"terrainType": "LAND"
+	},
+	"61,41": {
+		"terrainType": "LAND"
+	},
+	"61,42": {
+		"terrainType": "LAND"
+	},
+	"61,43": {
+		"terrainType": "LAND"
+	},
+	"61,44": {
+		"terrainType": "LAND"
+	},
+	"61,45": {
+		"terrainType": "LAND"
+	},
+	"61,46": {
+		"terrainType": "LAND"
+	},
+	"61,47": {
+		"terrainType": "LAND"
+	},
+	"61,48": {
+		"terrainType": "LAND"
+	},
+	"61,49": {
+		"terrainType": "LAND"
+	},
+	"61,50": {
+		"terrainType": "LAND"
+	},
+	"61,51": {
+		"terrainType": "LAND"
+	},
+	"61,52": {
+		"terrainType": "LAND"
+	},
+	"61,53": {
+		"terrainType": "LAND"
+	},
+	"61,54": {
+		"terrainType": "LAND"
+	},
+	"61,55": {
+		"terrainType": "LAND"
+	},
+	"61,56": {
+		"terrainType": "LAND"
+	},
+	"61,57": {
+		"terrainType": "LAND"
+	},
+	"61,58": {
+		"terrainType": "LAND"
+	},
+	"61,59": {
+		"terrainType": "LAND"
+	},
+	"61,60": {
+		"terrainType": "LAND"
+	},
+	"61,61": {
+		"terrainType": "LAND"
+	},
+	"61,62": {
+		"terrainType": "LAND"
+	},
+	"61,63": {
+		"terrainType": "LAND"
+	},
+	"62,0": {
+		"terrainType": "LAND"
+	},
+	"62,1": {
+		"terrainType": "LAND"
+	},
+	"62,2": {
+		"terrainType": "LAND"
+	},
+	"62,3": {
+		"terrainType": "LAND"
+	},
+	"62,4": {
+		"terrainType": "LAND"
+	},
+	"62,5": {
+		"terrainType": "LAND"
+	},
+	"62,6": {
+		"terrainType": "LAND"
+	},
+	"62,7": {
+		"terrainType": "LAND"
+	},
+	"62,8": {
+		"terrainType": "LAND"
+	},
+	"62,9": {
+		"terrainType": "LAND"
+	},
+	"62,10": {
+		"terrainType": "LAND"
+	},
+	"62,11": {
+		"terrainType": "LAND"
+	},
+	"62,12": {
+		"terrainType": "LAND"
+	},
+	"62,13": {
+		"terrainType": "LAND"
+	},
+	"62,14": {
+		"terrainType": "LAND"
+	},
+	"62,15": {
+		"terrainType": "LAND"
+	},
+	"62,16": {
+		"terrainType": "LAND"
+	},
+	"62,17": {
+		"terrainType": "LAND"
+	},
+	"62,18": {
+		"terrainType": "LAND"
+	},
+	"62,19": {
+		"terrainType": "LAND"
+	},
+	"62,20": {
+		"terrainType": "LAND"
+	},
+	"62,21": {
+		"terrainType": "LAND"
+	},
+	"62,22": {
+		"terrainType": "LAND"
+	},
+	"62,23": {
+		"terrainType": "LAND"
+	},
+	"62,24": {
+		"terrainType": "LAND"
+	},
+	"62,25": {
+		"terrainType": "LAND"
+	},
+	"62,26": {
+		"terrainType": "LAND"
+	},
+	"62,27": {
+		"terrainType": "LAND"
+	},
+	"62,28": {
+		"terrainType": "LAND"
+	},
+	"62,29": {
+		"terrainType": "LAND"
+	},
+	"62,30": {
+		"terrainType": "LAND"
+	},
+	"62,31": {
+		"terrainType": "LAND"
+	},
+	"62,32": {
+		"terrainType": "LAND"
+	},
+	"62,33": {
+		"terrainType": "LAND"
+	},
+	"62,34": {
+		"terrainType": "LAND"
+	},
+	"62,35": {
+		"terrainType": "LAND"
+	},
+	"62,36": {
+		"terrainType": "LAND"
+	},
+	"62,37": {
+		"terrainType": "LAND"
+	},
+	"62,38": {
+		"terrainType": "LAND"
+	},
+	"62,39": {
+		"terrainType": "LAND"
+	},
+	"62,40": {
+		"terrainType": "LAND"
+	},
+	"62,41": {
+		"terrainType": "LAND"
+	},
+	"62,42": {
+		"terrainType": "LAND"
+	},
+	"62,43": {
+		"terrainType": "LAND"
+	},
+	"62,44": {
+		"terrainType": "LAND"
+	},
+	"62,45": {
+		"terrainType": "LAND"
+	},
+	"62,46": {
+		"terrainType": "LAND"
+	},
+	"62,47": {
+		"terrainType": "LAND"
+	},
+	"62,48": {
+		"terrainType": "LAND"
+	},
+	"62,49": {
+		"terrainType": "LAND"
+	},
+	"62,50": {
+		"terrainType": "LAND"
+	},
+	"62,51": {
+		"terrainType": "LAND"
+	},
+	"62,52": {
+		"terrainType": "LAND"
+	},
+	"62,53": {
+		"terrainType": "LAND"
+	},
+	"62,54": {
+		"terrainType": "LAND"
+	},
+	"62,55": {
+		"terrainType": "LAND"
+	},
+	"62,56": {
+		"terrainType": "LAND"
+	},
+	"62,57": {
+		"terrainType": "LAND"
+	},
+	"62,58": {
+		"terrainType": "LAND"
+	},
+	"62,59": {
+		"terrainType": "LAND"
+	},
+	"62,60": {
+		"terrainType": "LAND"
+	},
+	"62,61": {
+		"terrainType": "LAND"
+	},
+	"62,62": {
+		"terrainType": "LAND"
+	},
+	"62,63": {
+		"terrainType": "LAND"
+	},
+	"63,0": {
+		"terrainType": "LAND"
+	},
+	"63,1": {
+		"terrainType": "LAND"
+	},
+	"63,2": {
+		"terrainType": "LAND"
+	},
+	"63,3": {
+		"terrainType": "LAND"
+	},
+	"63,4": {
+		"terrainType": "LAND"
+	},
+	"63,5": {
+		"terrainType": "LAND"
+	},
+	"63,6": {
+		"terrainType": "LAND"
+	},
+	"63,7": {
+		"terrainType": "LAND"
+	},
+	"63,8": {
+		"terrainType": "LAND"
+	},
+	"63,9": {
+		"terrainType": "LAND"
+	},
+	"63,10": {
+		"terrainType": "LAND"
+	},
+	"63,11": {
+		"terrainType": "LAND"
+	},
+	"63,12": {
+		"terrainType": "LAND"
+	},
+	"63,13": {
+		"terrainType": "LAND"
+	},
+	"63,14": {
+		"terrainType": "LAND"
+	},
+	"63,15": {
+		"terrainType": "LAND"
+	},
+	"63,16": {
+		"terrainType": "LAND"
+	},
+	"63,17": {
+		"terrainType": "LAND"
+	},
+	"63,18": {
+		"terrainType": "LAND"
+	},
+	"63,19": {
+		"terrainType": "LAND"
+	},
+	"63,20": {
+		"terrainType": "LAND"
+	},
+	"63,21": {
+		"terrainType": "LAND"
+	},
+	"63,22": {
+		"terrainType": "LAND"
+	},
+	"63,23": {
+		"terrainType": "LAND"
+	},
+	"63,24": {
+		"terrainType": "LAND"
+	},
+	"63,25": {
+		"terrainType": "LAND"
+	},
+	"63,26": {
+		"terrainType": "LAND"
+	},
+	"63,27": {
+		"terrainType": "LAND"
+	},
+	"63,28": {
+		"terrainType": "LAND"
+	},
+	"63,29": {
+		"terrainType": "LAND"
+	},
+	"63,30": {
+		"terrainType": "LAND"
+	},
+	"63,31": {
+		"terrainType": "LAND"
+	},
+	"63,32": {
+		"terrainType": "LAND"
+	},
+	"63,33": {
+		"terrainType": "LAND"
+	},
+	"63,34": {
+		"terrainType": "LAND"
+	},
+	"63,35": {
+		"terrainType": "LAND"
+	},
+	"63,36": {
+		"terrainType": "LAND"
+	},
+	"63,37": {
+		"terrainType": "LAND"
+	},
+	"63,38": {
+		"terrainType": "LAND"
+	},
+	"63,39": {
+		"terrainType": "LAND"
+	},
+	"63,40": {
+		"terrainType": "LAND"
+	},
+	"63,41": {
+		"terrainType": "LAND"
+	},
+	"63,42": {
+		"terrainType": "LAND"
+	},
+	"63,43": {
+		"terrainType": "LAND"
+	},
+	"63,44": {
+		"terrainType": "LAND"
+	},
+	"63,45": {
+		"terrainType": "LAND"
+	},
+	"63,46": {
+		"terrainType": "LAND"
+	},
+	"63,47": {
+		"terrainType": "LAND"
+	},
+	"63,48": {
+		"terrainType": "LAND"
+	},
+	"63,49": {
+		"terrainType": "LAND"
+	},
+	"63,50": {
+		"terrainType": "LAND"
+	},
+	"63,51": {
+		"terrainType": "LAND"
+	},
+	"63,52": {
+		"terrainType": "LAND"
+	},
+	"63,53": {
+		"terrainType": "LAND"
+	},
+	"63,54": {
+		"terrainType": "LAND"
+	},
+	"63,55": {
+		"terrainType": "LAND"
+	},
+	"63,56": {
+		"terrainType": "LAND"
+	},
+	"63,57": {
+		"terrainType": "LAND"
+	},
+	"63,58": {
+		"terrainType": "LAND"
+	},
+	"63,59": {
+		"terrainType": "LAND"
+	},
+	"63,60": {
+		"terrainType": "LAND"
+	},
+	"63,61": {
+		"terrainType": "LAND"
+	},
+	"63,62": {
+		"terrainType": "LAND"
+	},
+	"63,63": {
+		"terrainType": "LAND"
+	}
+}

--- a/packages/client/src/game/phaser/create/createTilemap.ts
+++ b/packages/client/src/game/phaser/create/createTilemap.ts
@@ -104,7 +104,7 @@ const createTilemap = (scene: Phaser.Scene) => {
 		const landOverlay = scene.add.graphics();
 		landOverlay.fillStyle(0x037a1e, 1);
 		landOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
-		landOverlay.lineStyle(4, 0x000000, 0.1);
+		landOverlay.lineStyle(5, 0xffffff, 0.2);
 		landOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
 		landMap[key] = landOverlay;
 	};
@@ -119,7 +119,7 @@ const createTilemap = (scene: Phaser.Scene) => {
 		const waterOverlay = scene.add.graphics();
 		waterOverlay.fillStyle(0x047dd9, 1);
 		waterOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
-		waterOverlay.lineStyle(4, 0x000000, 0.1);
+		waterOverlay.lineStyle(5, 0xffffff, 0.2);
 		waterOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
 		waterMap[key] = waterOverlay;
 	};

--- a/packages/client/src/game/phaser/create/createTilemap.ts
+++ b/packages/client/src/game/phaser/create/createTilemap.ts
@@ -62,7 +62,7 @@ const createTilemap = (scene: Phaser.Scene) => {
 	// Create a water map to store the water tiles
 	const waterMap: { [key: string]: Phaser.GameObjects.Graphics } = {};
 
-	const putFogAt = (tileCoord: Coord, opacity: number = 0.5) => {
+	const putFogAt = (tileCoord: Coord, opacity: number = 0.7) => {
 		const tileX =
 			(tileCoord.x + gridSize / 2) * tileWidth + startX * tileWidth;
 		const tileY =
@@ -117,6 +117,21 @@ const createTilemap = (scene: Phaser.Scene) => {
 
 		const key = `${tileCoord.x},${tileCoord.y}`;
 		const waterOverlay = scene.add.graphics();
+		waterOverlay.fillStyle(0x035797, 1);
+		waterOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
+		waterOverlay.lineStyle(5, 0xffffff, 0.2);
+		waterOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
+		waterMap[key] = waterOverlay;
+	};
+
+	const putShallowWaterAt = (tileCoord: Coord) => {
+		const tileX =
+			(tileCoord.x + gridSize / 2) * tileWidth + startX * tileWidth;
+		const tileY =
+			(tileCoord.y + gridSize / 2) * tileHeight + startY * tileHeight;
+
+		const key = `${tileCoord.x},${tileCoord.y}`;
+		const waterOverlay = scene.add.graphics();
 		waterOverlay.fillStyle(0x047dd9, 1);
 		waterOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
 		waterOverlay.lineStyle(5, 0xffffff, 0.2);
@@ -134,6 +149,7 @@ const createTilemap = (scene: Phaser.Scene) => {
 		removeFogAt,
 		putLandAt,
 		putWaterAt,
+		putShallowWaterAt,
 		...config.tilemap,
 	};
 };

--- a/packages/client/src/game/phaser/create/createTilemap.ts
+++ b/packages/client/src/game/phaser/create/createTilemap.ts
@@ -57,6 +57,10 @@ const createTilemap = (scene: Phaser.Scene) => {
 
 	// Create a fog map to store the fog overlays for each tile
 	const fogMap: { [key: string]: Phaser.GameObjects.Graphics } = {};
+	// Create a land map to store the land tiles
+	const landMap: { [key: string]: Phaser.GameObjects.Graphics } = {};
+	// Create a water map to store the water tiles
+	const waterMap: { [key: string]: Phaser.GameObjects.Graphics } = {};
 
 	const putFogAt = (tileCoord: Coord, opacity: number = 0.5) => {
 		const tileX =
@@ -90,6 +94,36 @@ const createTilemap = (scene: Phaser.Scene) => {
 		}
 	}
 
+	const putLandAt = (tileCoord: Coord) => {
+		const tileX =
+			(tileCoord.x + gridSize / 2) * tileWidth + startX * tileWidth;
+		const tileY =
+			(tileCoord.y + gridSize / 2) * tileHeight + startY * tileHeight;
+
+		const key = `${tileCoord.x},${tileCoord.y}`;
+		const landOverlay = scene.add.graphics();
+		landOverlay.fillStyle(0x037a1e, 1);
+		landOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
+		landOverlay.lineStyle(2, 0x000000, 0.1);
+		landOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
+		landMap[key] = landOverlay;
+	};
+
+	const putWaterAt = (tileCoord: Coord) => {
+		const tileX =
+			(tileCoord.x + gridSize / 2) * tileWidth + startX * tileWidth;
+		const tileY =
+			(tileCoord.y + gridSize / 2) * tileHeight + startY * tileHeight;
+
+		const key = `${tileCoord.x},${tileCoord.y}`;
+		const waterOverlay = scene.add.graphics();
+		waterOverlay.fillStyle(0x05acfe, 1);
+		waterOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
+		waterOverlay.lineStyle(2, 0x000000, 0.1);
+		waterOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
+		waterMap[key] = waterOverlay;
+	};
+
 	return {
 		tilemap,
 		layer,
@@ -98,6 +132,8 @@ const createTilemap = (scene: Phaser.Scene) => {
 		getTileAt,
 		putFogAt,
 		removeFogAt,
+		putLandAt,
+		putWaterAt,
 		...config.tilemap,
 	};
 };

--- a/packages/client/src/game/phaser/create/createTilemap.ts
+++ b/packages/client/src/game/phaser/create/createTilemap.ts
@@ -104,7 +104,7 @@ const createTilemap = (scene: Phaser.Scene) => {
 		const landOverlay = scene.add.graphics();
 		landOverlay.fillStyle(0x037a1e, 1);
 		landOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
-		landOverlay.lineStyle(2, 0x000000, 0.1);
+		landOverlay.lineStyle(4, 0x000000, 0.1);
 		landOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
 		landMap[key] = landOverlay;
 	};
@@ -117,9 +117,9 @@ const createTilemap = (scene: Phaser.Scene) => {
 
 		const key = `${tileCoord.x},${tileCoord.y}`;
 		const waterOverlay = scene.add.graphics();
-		waterOverlay.fillStyle(0x05acfe, 1);
+		waterOverlay.fillStyle(0x047dd9, 1);
 		waterOverlay.fillRect(tileX, tileY, tileWidth, tileHeight);
-		waterOverlay.lineStyle(2, 0x000000, 0.1);
+		waterOverlay.lineStyle(4, 0x000000, 0.1);
 		waterOverlay.strokeRect(tileX, tileY, tileWidth, tileHeight);
 		waterMap[key] = waterOverlay;
 	};

--- a/packages/client/src/game/phaser/syncPhaser.ts
+++ b/packages/client/src/game/phaser/syncPhaser.ts
@@ -5,7 +5,11 @@ import { getPlayerId } from "../../utils/getPlayerId";
 import { type Api, Direction } from "../createApi";
 import type { PhaserGame } from "../phaser/create/createPhaserGame";
 import type { Coord, TileWithCoord } from "../store";
-import useStore, { GameState, NEXT_MOVE_TIME_MILLIS } from "../store";
+import useStore, {
+	GameState,
+	NEXT_MOVE_TIME_MILLIS,
+	TerrainType,
+} from "../store";
 import { createTileFetcher } from "./create/createTileFetcher";
 import phaserConfig from "./create/phaserConfig";
 import { updatePlayer } from "../../utils/updatePlayer";
@@ -239,9 +243,22 @@ const syncPhaser = async (game: PhaserGame, api: Api) => {
 		return go;
 	};
 
+	const drawTerrain = () => {
+		const grid = useStore.getState().grid;
+		grid.forEach((tile) => {
+			if (tile.terrainType === TerrainType.LAND) {
+				game.tilemap.putLandAt(tile.coord);
+			}
+			if (tile.terrainType === TerrainType.WATER) {
+				game.tilemap.putWaterAt(tile.coord);
+			}
+		});
+	};
+
 	const setupGame = () => {
-		positionCamera(initialPlayerCoord);
+		drawTerrain();
 		drawSelectedPlayer(initialPlayerCoord);
+		positionCamera(initialPlayerCoord);
 		tileFetcher.start();
 
 		game.input.keyboard$.pipe(debounceTime(200)).subscribe((key) => {

--- a/packages/client/src/game/phaser/syncPhaser.ts
+++ b/packages/client/src/game/phaser/syncPhaser.ts
@@ -276,7 +276,11 @@ const syncPhaser = async (game: PhaserGame, api: Api) => {
 				game.tilemap.putLandAt(tile.coord);
 			}
 			if (tile.terrainType === TerrainType.WATER) {
-				game.tilemap.putWaterAt(tile.coord);
+				if (tile.isBorderingLand) {
+					game.tilemap.putShallowWaterAt(tile.coord);
+				} else {
+					game.tilemap.putWaterAt(tile.coord);
+				}
 			}
 		});
 	};

--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -17,8 +17,8 @@ export type Tile = {
 };
 
 export enum TerrainType {
-	LAND = "Land",
-	WATER = "Water",
+	LAND = "LAND",
+	WATER = "WATER",
 }
 
 export type TileWithCoord = Tile & {
@@ -94,7 +94,8 @@ const initializeGrid = (
 	for (let x = 0; x < size; x++) {
 		for (let y = 0; y < size; y++) {
 			const coordKey = coordToKey({ x, y });
-			const tileConfig = config[coordKey] || {};
+			const tileConfigKey = `${x},${y}`;
+			const tileConfig = config[tileConfigKey] || {};
 
 			grid.set(coordKey, {
 				coord: { x, y },

--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -215,7 +215,9 @@ const useStore = create<State>()(
 
 					// Update the grid with the newly fetched tile value (overrides the isShown: false set above)
 					if (newGrid.has(coordKey)) {
+						const existingTile = newGrid.get(coordKey);
 						newGrid.set(coordKey, {
+							...existingTile,
 							...tile,
 							isShown: true,
 						});

--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -15,7 +15,13 @@ export type Tile = {
 	hp: number;
 };
 
+export enum TerrainType {
+	LAND = "Land",
+	WATER = "Water",
+}
+
 export type TileWithCoord = Tile & {
+	terrainType: TerrainType;
 	coord: Coord; // phaser coordinate of the tile
 	isShown?: boolean; // if the tile is shown in the game
 	fetchedAt: number; // timestamp of when the tile was fetched
@@ -86,6 +92,7 @@ const initializeGrid = (size: number) => {
 			const coordKey = coordToKey({ x, y });
 			grid.set(coordKey, {
 				coord: { x, y },
+				terrainType: x === 0 ? TerrainType.WATER : TerrainType.LAND,
 				entity_type: "None",
 				fetchedAt: 0,
 				isShown: false,

--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -6,6 +6,10 @@ import { coordToKey } from "@smallbraingames/small-phaser";
 import { immer } from "zustand/middleware/immer";
 import { GameResponse } from "../utils/fetchGame";
 import tileConfig from "../const/tile.config.json";
+import {
+	findBorderingWaterCoordinates,
+	Grid,
+} from "../utils/findBorderingWaterCoordinates";
 
 export type TileEntityType = "None" | "Player" | "Item";
 
@@ -23,6 +27,7 @@ export enum TerrainType {
 
 export type TileWithCoord = Tile & {
 	terrainType: TerrainType;
+	isBorderingLand: boolean; // if its a water tile that is bordering land
 	coord: Coord; // phaser coordinate of the tile
 	isShown?: boolean; // if the tile is shown in the game
 	fetchedAt: number; // timestamp of when the tile was fetched
@@ -91,6 +96,9 @@ const initializeGrid = (
 	config: Record<string, { terrainType: string }>,
 ) => {
 	const grid = new Map();
+	const waterCoordinatesBorderingLand = findBorderingWaterCoordinates(
+		config as Grid,
+	);
 	for (let x = 0; x < size; x++) {
 		for (let y = 0; y < size; y++) {
 			const coordKey = coordToKey({ x, y });
@@ -100,6 +108,8 @@ const initializeGrid = (
 			grid.set(coordKey, {
 				coord: { x, y },
 				terrainType: tileConfig.terrainType,
+				isBorderingLand:
+					waterCoordinatesBorderingLand.includes(tileConfigKey),
 				entity_type: "None",
 				fetchedAt: 0,
 				isShown: false,

--- a/packages/client/src/game/store.ts
+++ b/packages/client/src/game/store.ts
@@ -5,6 +5,7 @@ enableMapSet();
 import { coordToKey } from "@smallbraingames/small-phaser";
 import { immer } from "zustand/middleware/immer";
 import { GameResponse } from "../utils/fetchGame";
+import tileConfig from "../const/tile.config.json";
 
 export type TileEntityType = "None" | "Player" | "Item";
 
@@ -85,14 +86,19 @@ interface State {
 	updateGrid: (viewportCoords: Coord[], newTiles: TileWithCoord[]) => void;
 }
 
-const initializeGrid = (size: number) => {
+const initializeGrid = (
+	size: number,
+	config: Record<string, { terrainType: string }>,
+) => {
 	const grid = new Map();
 	for (let x = 0; x < size; x++) {
 		for (let y = 0; y < size; y++) {
 			const coordKey = coordToKey({ x, y });
+			const tileConfig = config[coordKey] || {};
+
 			grid.set(coordKey, {
 				coord: { x, y },
-				terrainType: x === 0 ? TerrainType.WATER : TerrainType.LAND,
+				terrainType: tileConfig.terrainType,
 				entity_type: "None",
 				fetchedAt: 0,
 				isShown: false,
@@ -110,7 +116,7 @@ const useStore = create<State>()(
 		gameState: GameState.LOADING,
 		players: new Map<number, Player>(),
 		items: new Map<number, Item>(),
-		grid: initializeGrid(64),
+		grid: initializeGrid(64, tileConfig),
 		lastMoveTimeStamp: 0, // Store the last move timestamp
 		setIsLoggedIn: ({
 			isLoggedIn,

--- a/packages/client/src/utils/findBorderingWaterCoordinates.ts
+++ b/packages/client/src/utils/findBorderingWaterCoordinates.ts
@@ -1,0 +1,32 @@
+import { TerrainType } from "../game/store";
+
+export interface Grid {
+	[key: string]: {
+		terrainType: TerrainType;
+	};
+}
+
+export const findBorderingWaterCoordinates = (grid: Grid): string[] => {
+	const result: string[] = [];
+	const getNeighbors = (x: number, y: number): string[] => [
+		`${x - 1},${y}`, // Up
+		`${x + 1},${y}`, // Down
+		`${x},${y - 1}`, // Left
+		`${x},${y + 1}`, // Right
+	];
+
+	for (const key in grid) {
+		if (grid[key as keyof Grid].terrainType === "WATER") {
+			const [x, y] = key.split(",").map(Number);
+
+			const hasLandNeighbor = getNeighbors(x, y).some(
+				(neighbor) => grid[neighbor]?.terrainType === "LAND",
+			);
+			if (hasLandNeighbor) {
+				result.push(key);
+			}
+		}
+	}
+
+	return result;
+};

--- a/packages/client/tsconfig.app.json
+++ b/packages/client/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+	"resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Adds a tilemap / water and land terrain to the game. 

<img width="1065" alt="Screenshot 2024-10-31 at 11 49 46 AM" src="https://github.com/user-attachments/assets/41cd01b2-e830-4bce-b207-add8075cce74">

Tilemap is generated from a json config file at const/tilemap.config.ts 

Introduces a check client-side before calling api/move that prevents a user from moving on to water tiles.

Adds an editor component that can be opened using CTRL + E, in which the full grid can be visualized clicked to be toggled between land and water and exported as JSON in the correct format for quick and easy changes.
<img width="1019" alt="Screenshot 2024-10-31 at 11 52 26 AM" src="https://github.com/user-attachments/assets/19577a7f-c3e9-4b3a-8a5f-a741517c4779">

Saves the coordinates of tiles that border land, these are rendered as shallow water  (lighter blue) on the map. 
