### PR TITLE
add a fallback to assetKey in case we have more items than in the config

### DIFF
--- a/packages/client/src/game/phaser/syncPhaser.ts
+++ b/packages/client/src/game/phaser/syncPhaser.ts
@@ -1,3 +1,4 @@
+import { Player } from "./../store";
 import {
 	coordToKey,
 	getCenterPixelCoord,
@@ -126,7 +127,8 @@ const syncPhaser = async (game: PhaserGame, api: Api) => {
 						}
 						const itemGameObject = addItem(
 							tile.coord,
-							ENTITIES_CONFIG.items[id].assetKey,
+							ENTITIES_CONFIG.items[id]?.assetKey ??
+								phaserConfig.assetKeys.item,
 						);
 						items.set(id, {
 							image: itemGameObject,
@@ -149,10 +151,10 @@ const syncPhaser = async (game: PhaserGame, api: Api) => {
 						}
 						const monsterGameObject = addMonster(
 							tile.coord,
-							ENTITIES_CONFIG.monsters[id].assetKey ??
+							ENTITIES_CONFIG.monsters[id]?.assetKey ??
 								phaserConfig.assetKeys.monster,
 						);
-						items.set(id, {
+						monsters.set(id, {
 							image: monsterGameObject,
 							coord: tile.coord,
 						});
@@ -178,7 +180,9 @@ const syncPhaser = async (game: PhaserGame, api: Api) => {
 							}
 							const playerGameObject = addPlayer({
 								coord: tile.coord,
-								assetKey: ENTITIES_CONFIG.players[id].assetKey,
+								assetKey:
+									ENTITIES_CONFIG.players[id]?.assetKey ??
+									phaserConfig.assetKeys.frog,
 							});
 							players.set(tile.entity_id, {
 								image: playerGameObject,


### PR DESCRIPTION
Fixes missing fallbacks where we have more items or monsters than actually in the config.