### PR TITLE
add a endpoint for getting the scoreboard and display in simple table

### DIFF
--- a/packages/login/app/api/scoreboard/route.ts
+++ b/packages/login/app/api/scoreboard/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma/init";
+
+export async function GET() {
+  try {
+    // Query to get the aggregated scores for each player
+    const scoreboard = await prisma.playerGame.groupBy({
+      by: ["publicKey"],
+      _sum: { score: true },
+      orderBy: { _sum: { score: "desc" } }, // Sort by highest scores
+    });
+
+    // Format the response to match the expected output structure
+    const response = scoreboard.map((player) => ({
+      publicKey: player.publicKey,
+      score: player._sum.score,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      players: response,
+    });
+  } catch (error) {
+    console.error("Error retrieving scoreboard:", error);
+
+    return NextResponse.json(
+      { success: false, message: "Failed to retrieve scoreboard" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/login/app/score-board/page.tsx
+++ b/packages/login/app/score-board/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Player {
+  publicKey: string;
+  score: number;
+}
+
+export default function Scoreboard() {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchScores = async () => {
+      try {
+        const response = await fetch("/api/scoreboard");
+        if (!response.ok) {
+          throw new Error("Failed to fetch scoreboard data");
+        }
+        const data = await response.json();
+        setPlayers(data.players);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchScores();
+  }, []);
+
+  const truncatePublicKey = (key: string): string => {
+    return key.length > 10 ? `${key.slice(0, 6)}...${key.slice(-3)}` : key;
+  };
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error}</p>;
+
+  return (
+    <div className="bg-black text-white min-h-screen p-8">
+      <h1 className="font-bold text-2xl mb-6">Scoreboard</h1>
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th className="border-b border-gray-700 p-4 text-left">
+              Player Public Key
+            </th>
+            <th className="border-b border-gray-700 p-4 text-left">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((player, index) => (
+            <tr key={index} className="even:bg-gray-900">
+              <td className="p-4">
+                {index + 1}. {truncatePublicKey(player.publicKey)}
+                {index === 0 && " 🏆"}
+              </td>
+              <td className="p-4">{player.score}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a simple global scoreboard (basic UI and endpoint):
<img width="1792" alt="Screenshot 2024-11-07 at 9 27 14 AM" src="https://github.com/user-attachments/assets/398aa9c2-64b3-49f7-b09d-73026ddfb0e2">
